### PR TITLE
fix: Don't cleanup multi arch images

### DIFF
--- a/.github/workflows/cleanup-artifacts.yml
+++ b/.github/workflows/cleanup-artifacts.yml
@@ -17,15 +17,32 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Delete PR images, old dev builds, and untagged container versions
+      - name: Delete PR images, old dev builds, and unreferenced untagged manifests
         uses: actions/github-script@v9.0.0
+        env:
+          GHCR_TOKEN: ${{ github.token }}
         with:
           script: |
             const owner = context.repo.owner;
             const ownerType = context.payload.repository.owner.type;
             const packageName = 'csi-driver-for-windows-storage-server';
+            const registryRepo = `${owner.toLowerCase()}/${packageName}`;
             const prTagPrefix = 'pr-';
             const devTagPrefix = 'dev-';
+            const keepDevBuilds = 5;
+
+            const manifestAccept = [
+              'application/vnd.oci.image.index.v1+json',
+              'application/vnd.docker.distribution.manifest.list.v2+json',
+              'application/vnd.oci.image.manifest.v1+json',
+              'application/vnd.docker.distribution.manifest.v2+json',
+            ].join(', ');
+
+            const tagsFor = (version) => version.metadata?.container?.tags || [];
+            const digestFrom = (value) => {
+              const match = String(value || '').match(/sha256:[a-f0-9]{64}/i);
+              return match ? match[0].toLowerCase() : '';
+            };
 
             const getVersions = async (targetPackage) => {
               const params = {
@@ -44,8 +61,7 @@ jobs:
                 params.org = owner;
               }
 
-              const { data } = await method(params);
-              return data;
+              return await github.paginate(method, params);
             };
 
             const deleteVersion = async (targetPackage, versionId) => {
@@ -68,29 +84,165 @@ jobs:
               await method(params);
             };
 
+            let registryToken;
+            const getRegistryToken = async () => {
+              if (registryToken) {
+                return registryToken;
+              }
+
+              const token = process.env.GHCR_TOKEN;
+              if (!token) {
+                throw new Error('GHCR_TOKEN is not set');
+              }
+
+              const basicAuth = Buffer.from(`${context.actor}:${token}`).toString('base64');
+              const response = await fetch(`https://ghcr.io/token?service=ghcr.io&scope=repository:${registryRepo}:pull`, {
+                headers: {
+                  Authorization: `Basic ${basicAuth}`,
+                },
+              });
+
+              if (!response.ok) {
+                throw new Error(`Failed to get GHCR registry token: ${response.status} ${await response.text()}`);
+              }
+
+              const body = await response.json();
+              registryToken = body.token;
+              if (!registryToken) {
+                throw new Error('GHCR registry token response did not include a token');
+              }
+              return registryToken;
+            };
+
+            const fetchManifest = async (reference) => {
+              const token = await getRegistryToken();
+              const response = await fetch(`https://ghcr.io/v2/${registryRepo}/manifests/${encodeURIComponent(reference)}`, {
+                headers: {
+                  Authorization: `Bearer ${token}`,
+                  Accept: manifestAccept,
+                },
+              });
+
+              if (response.status === 404) {
+                core.warning(`Manifest ${registryRepo}@${reference} was not found while building the protected digest set`);
+                return null;
+              }
+              if (!response.ok) {
+                throw new Error(`Failed to fetch manifest ${registryRepo}@${reference}: ${response.status} ${await response.text()}`);
+              }
+
+              const text = await response.text();
+              return {
+                digest: digestFrom(response.headers.get('docker-content-digest')),
+                body: text ? JSON.parse(text) : {},
+              };
+            };
+
+            const protectedDigests = new Set();
+            const visitedManifestRefs = new Set();
+
+            const protectManifest = async (reference) => {
+              const ref = String(reference || '').trim();
+              if (!ref || visitedManifestRefs.has(ref)) {
+                return;
+              }
+              visitedManifestRefs.add(ref);
+
+              const refDigest = digestFrom(ref);
+              if (refDigest) {
+                protectedDigests.add(refDigest);
+              }
+
+              const manifest = await fetchManifest(ref);
+              if (!manifest) {
+                return;
+              }
+              if (manifest.digest) {
+                protectedDigests.add(manifest.digest);
+              }
+
+              const childManifests = Array.isArray(manifest.body?.manifests) ? manifest.body.manifests : [];
+              for (const child of childManifests) {
+                const childDigest = digestFrom(child.digest);
+                if (!childDigest) {
+                  continue;
+                }
+                protectedDigests.add(childDigest);
+                await protectManifest(childDigest);
+              }
+            };
+
             try {
               const versions = await getVersions(packageName);
-              const devBuilds = [];
+              const devBuilds = versions.filter((version) => tagsFor(version).some((tag) => tag.startsWith(devTagPrefix)));
+
+              devBuilds.sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at));
+              const keptDevBuildIds = new Set(devBuilds.slice(0, keepDevBuilds).map((version) => version.id));
+              const taggedVersionIdsToDelete = new Set();
 
               for (const version of versions) {
-                const tags = version.metadata?.container?.tags || [];
+                const tags = tagsFor(version);
                 const isTaggedRelease = tags.some((tag) => /^\d+\.\d+\.\d+/.test(tag) || tag === 'latest');
                 const isDevBuild = tags.some((tag) => tag.startsWith(devTagPrefix));
                 const isPrBuild = tags.some((tag) => tag.startsWith(prTagPrefix));
-                const isUntagged = tags.length === 0;
 
-                if (!isTaggedRelease && (isPrBuild || isUntagged)) {
-                  core.info(`Deleting container version ${version.id} (${tags.join(', ') || 'untagged'})`);
-                  await deleteVersion(packageName, version.id);
-                } else if (isDevBuild) {
-                  devBuilds.push(version);
+                if (!isTaggedRelease && isPrBuild) {
+                  taggedVersionIdsToDelete.add(version.id);
+                } else if (!isTaggedRelease && isDevBuild && !keptDevBuildIds.has(version.id)) {
+                  taggedVersionIdsToDelete.add(version.id);
                 }
               }
 
-              devBuilds.sort((a, b) => new Date(b.updated_at) - new Date(a.updated_at));
+              const keptTaggedVersions = versions.filter((version) => {
+                const tags = tagsFor(version);
+                return tags.length > 0 && !taggedVersionIdsToDelete.has(version.id);
+              });
 
-              for (const version of devBuilds.slice(5)) {
-                core.info(`Deleting old dev container build ${version.id}`);
+              for (const version of keptTaggedVersions) {
+                const tags = tagsFor(version);
+                const digest = digestFrom(version.name);
+                const refs = digest ? [digest, ...tags] : tags;
+                core.info(`Protecting manifests referenced by container version ${version.id} (${tags.join(', ')})`);
+                for (const ref of refs) {
+                  await protectManifest(ref);
+                }
+              }
+              core.info(`Protected ${protectedDigests.size} manifest digest(s) referenced by kept tags`);
+
+              for (const version of versions) {
+                if (!taggedVersionIdsToDelete.has(version.id)) {
+                  continue;
+                }
+
+                const tags = tagsFor(version);
+                const digest = digestFrom(version.name);
+                if (digest && protectedDigests.has(digest)) {
+                  core.info(`Keeping container version ${version.id} (${tags.join(', ')}) because digest ${digest} is referenced by a kept tag`);
+                  continue;
+                }
+
+                core.info(`Deleting tagged container version ${version.id} (${tags.join(', ')})`);
+                await deleteVersion(packageName, version.id);
+              }
+
+              for (const version of versions) {
+                const tags = tagsFor(version);
+                if (tags.length > 0) {
+                  continue;
+                }
+
+                const digest = digestFrom(version.name);
+                if (!digest) {
+                  core.info(`Keeping untagged container version ${version.id} because its digest could not be determined`);
+                  continue;
+                }
+
+                if (protectedDigests.has(digest)) {
+                  core.info(`Keeping untagged container version ${version.id}; digest ${digest} is referenced by a kept tag`);
+                  continue;
+                }
+
+                core.info(`Deleting unreferenced untagged container version ${version.id} (${digest})`);
                 await deleteVersion(packageName, version.id);
               }
             } catch (error) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,16 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Validate release token
+        env:
+          RELEASE_TOKEN: ${{ secrets.GHCR_PASSWORD }}
+        run: |
+          if [[ -z "${RELEASE_TOKEN}" ]]; then
+            echo "The GHCR_PASSWORD secret must contain a token that can push release commits and tags."
+            echo "Create it in Settings > Secrets and variables > Actions > Repository secrets."
+            exit 1
+          fi
+
       - name: Checkout source
         uses: actions/checkout@v6.0.2
         with:

--- a/README.md
+++ b/README.md
@@ -171,31 +171,31 @@ The project provides a Makefile for common developer tasks.
 | make release       | Run goreleaser to build and release         |
 | make clean         | Clean up build artifacts                    |
 
-#### Example: Build the driver
+#### Build the driver
 
 ```sh
 make build
 ```
 
-#### Example: Run tests
+#### Run tests
 
 ```sh
 make test
 ```
 
-#### Example: Lint and format
+#### Lint and format
 
 ```sh
 make lint
 ```
 
-#### Example: Build Docker image
+#### Build Docker image
 
 ```sh
 make image
 ```
 
-#### Example: Release with goreleaser
+#### Release with goreleaser
 
 ```sh
 make release
@@ -252,36 +252,33 @@ The chart is published as an OCI artifact to GHCR at `oci://ghcr.io/taliesins/he
 #### 1. Install from GHCR
 
 ```sh
-helm install csi-driver-for-windows-storage-server oci://ghcr.io/taliesins/helm/csi-driver-for-windows-storage-server \
-  --namespace kube-system \
-  --create-namespace
+helm upgrade --install --create-namespace csi-driver-for-windows-storage-server oci://ghcr.io/taliesins/helm/csi-driver-for-windows-storage-server -n=kube-system
 ```
 
 #### 2. Specify a version
 
 ```sh
-helm install csi-driver-for-windows-storage-server oci://ghcr.io/taliesins/helm/csi-driver-for-windows-storage-server \
-  --namespace kube-system \
-  --create-namespace \
-  --version 0.1.0
+helm upgrade --install --create-namespace csi-driver-for-windows-storage-server oci://ghcr.io/taliesins/helm/csi-driver-for-windows-storage-server --version=1.0.0 -n=kube-system
 ```
 
 #### 3. Customize values (optional)
 
-Override any value from [`values.yaml`](./chart/csi-driver-for-windows-storage-server/values.yaml):
+Override any value from [`values.yaml`](./chart/csi-driver-for-windows-storage-server/values.yaml) by putting your changes in a values file, for example `csi-driver-overrides.yaml`:
+
+```yaml
+image:
+  tag: 1.0.0
+  pullPolicy: Always
+```
 
 ```sh
-helm install csi-driver-for-windows-storage-server oci://ghcr.io/taliesins/helm/csi-driver-for-windows-storage-server \
-  --namespace kube-system \
-  --create-namespace \
-  --set image.tag=0.2.0 \
-  --set image.pullPolicy=Always
+helm upgrade --install --create-namespace csi-driver-for-windows-storage-server oci://ghcr.io/taliesins/helm/csi-driver-for-windows-storage-server --version=1.0.0 -n=kube-system -f csi-driver-overrides.yaml
 ```
 
 #### 4. Verify the installation
 
 ```sh
-helm status csi-driver-for-windows-storage-server -n kube-system
+helm status csi-driver-for-windows-storage-server -n=kube-system
 
 kubectl get pods -n kube-system -l app.kubernetes.io/instance=csi-driver-for-windows-storage-server
 ```
@@ -290,11 +287,10 @@ kubectl get pods -n kube-system -l app.kubernetes.io/instance=csi-driver-for-win
 
 ```sh
 # Upgrade
-helm upgrade csi-driver-for-windows-storage-server oci://ghcr.io/taliesins/helm/csi-driver-for-windows-storage-server \
-  --namespace kube-system
+helm upgrade --install --create-namespace csi-driver-for-windows-storage-server oci://ghcr.io/taliesins/helm/csi-driver-for-windows-storage-server -n=kube-system
 
 # Uninstall
-helm uninstall csi-driver-for-windows-storage-server -n kube-system
+helm uninstall csi-driver-for-windows-storage-server -n=kube-system
 ```
 
 ### Install via Helm (local chart)
@@ -302,9 +298,7 @@ helm uninstall csi-driver-for-windows-storage-server -n kube-system
 For development or air-gapped environments, you can install from the local chart directory:
 
 ```sh
-helm install csi-driver-for-windows-storage-server ./chart/csi-driver-for-windows-storage-server \
-  --namespace kube-system \
-  --create-namespace
+helm upgrade --install --create-namespace csi-driver-for-windows-storage-server ./chart/csi-driver-for-windows-storage-server -n=kube-system
 ```
 
 ### Build and publish
@@ -314,8 +308,8 @@ CI builds and validates pull requests, publishes `dev-<sha>` and `dev` container
 ```sh
 make image IMAGE_TAG=dev
 make image-push IMAGE_TAG=dev
-make chart-package CHART_VERSION=0.1.0 APP_VERSION=dev
-make chart-push CHART_VERSION=0.1.0 APP_VERSION=dev
+make chart-package CHART_VERSION=1.0.0 APP_VERSION=dev
+make chart-push CHART_VERSION=1.0.0 APP_VERSION=dev
 ```
 
 For a release, run the `Create Release Tag` workflow. Semantic-release reads the conventional squash-merge commits since the previous release, calculates the next SemVer version, updates `CHANGELOG.md`, creates the `vX.Y.Z` tag, and opens the GitHub release. The tag push publishes `ghcr.io/taliesins/csi-driver-for-windows-storage-server:X.Y.Z`, `:latest`, and the matching OCI Helm chart.
@@ -390,17 +384,14 @@ The tag push triggers the publish job.
 
 The release publish creates:
 
-- Container image: `ghcr.io/taliesins/csi-driver-for-windows-storage-server:0.2.0`
+- Container image: `ghcr.io/taliesins/csi-driver-for-windows-storage-server:1.0.0`
 - Mutable release image: `ghcr.io/taliesins/csi-driver-for-windows-storage-server:latest`
-- Helm chart: `oci://ghcr.io/taliesins/helm/csi-driver-for-windows-storage-server` with version `0.2.0`
+- Helm chart: `oci://ghcr.io/taliesins/helm/csi-driver-for-windows-storage-server` with version `1.0.0`
 
 Install a released chart with:
 
 ```sh
-helm install csi-driver-for-windows-storage-server oci://ghcr.io/taliesins/helm/csi-driver-for-windows-storage-server \
-  --namespace kube-system \
-  --create-namespace \
-  --version 0.2.0
+helm upgrade --install --create-namespace csi-driver-for-windows-storage-server oci://ghcr.io/taliesins/helm/csi-driver-for-windows-storage-server --version=1.0.0 -n=kube-system
 ```
 
 ### Troubleshooting

--- a/pkg/iscsi/nodeserver.go
+++ b/pkg/iscsi/nodeserver.go
@@ -21,6 +21,9 @@ import (
 var (
 	iscsilibConnect      = func(c *iscsilib.Connector) (string, error) { return c.Connect() }
 	getConnectorFromFile = iscsilib.GetConnectorFromFile
+	formatAndMount       = func(m *mount.SafeFormatAndMount, source, target, fsType string, options []string) error {
+		return m.FormatAndMount(source, target, fsType, options)
+	}
 	iscsilibExpandVolume = func(m mount.Interface, resizer iscsilib.Resizer, volumePath string) error {
 		return iscsilib.ExpandVolume(m, resizer, volumePath)
 	}
@@ -58,6 +61,16 @@ func (ns *nodeServer) init() error {
 func getStr(m map[string]string, k string) (string, bool) {
 	v, ok := m[k]
 	return strings.TrimSpace(v), ok && strings.TrimSpace(v) != ""
+}
+
+func fsTypeFromCapability(vc *csi.VolumeCapability) string {
+	if vc == nil {
+		return ""
+	}
+	if mount := vc.GetMount(); mount != nil {
+		return strings.TrimSpace(mount.GetFsType())
+	}
+	return ""
 }
 
 func isBlockDevice(p string) (bool, error) {
@@ -160,9 +173,10 @@ func (ns *nodeServer) parseStage(req *csi.NodeStageVolumeRequest) (portal, iqn s
 	}
 	lun = li
 
+	fsType = fsTypeFromCapability(req.GetVolumeCapability())
 	vc := req.GetVolumeContext()
 	if vc != nil {
-		if v, ok := getStr(vc, "fsType"); ok {
+		if v, ok := getStr(vc, "fsType"); ok && fsType == "" {
 			fsType = v
 		}
 		if v, ok := getStr(vc, "mountOptions"); ok {
@@ -218,9 +232,10 @@ func (ns *nodeServer) parsePublish(req *csi.NodePublishVolumeRequest) (portal, i
 	}
 	lun = li
 
+	fsType = fsTypeFromCapability(req.GetVolumeCapability())
 	vc := req.GetVolumeContext()
 	if vc != nil {
-		if v, ok := getStr(vc, "fsType"); ok {
+		if v, ok := getStr(vc, "fsType"); ok && fsType == "" {
 			fsType = v
 		}
 		if v, ok := getStr(vc, "mountOptions"); ok {
@@ -430,7 +445,7 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, status.Errorf(codes.Internal, "mkdir staging: %v", err)
 	}
 	if notMnt {
-		if err := ns.mounter.FormatAndMount(device, req.GetStagingTargetPath(), fsType, mountOpts); err != nil {
+		if err := formatAndMount(ns.mounter, device, req.GetStagingTargetPath(), fsType, mountOpts); err != nil {
 			return nil, status.Errorf(codes.Internal, "format+mount staging failed: %v", err)
 		}
 	}
@@ -555,7 +570,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 					return nil, status.Errorf(codes.Internal, "recover staging path: %v", err)
 				}
 			}
-			if err := ns.mounter.FormatAndMount(device, staging, fsType, mountOpts); err != nil {
+			if err := formatAndMount(ns.mounter, device, staging, fsType, mountOpts); err != nil {
 				return nil, status.Errorf(codes.Internal, "format+mount staging fallback failed: %v", err)
 			}
 		}

--- a/pkg/iscsi/nodeserver_test.go
+++ b/pkg/iscsi/nodeserver_test.go
@@ -226,6 +226,96 @@ func TestNodeStageVolume_BlockVolume(t *testing.T) {
 	assert.Empty(t, mockMount.formatAndMounts)
 }
 
+func TestNodeStageVolume_FilesystemFsType(t *testing.T) {
+	tests := []struct {
+		name             string
+		capabilityFsType string
+		volumeContext    map[string]string
+		wantFsType       string
+		wantOptions      []string
+	}{
+		{
+			name:             "uses CSI mount fs type",
+			capabilityFsType: "xfs",
+			volumeContext:    map[string]string{"mountOptions": "discard,noatime"},
+			wantFsType:       "xfs",
+			wantOptions:      []string{"discard", "noatime"},
+		},
+		{
+			name:             "trims CSI mount fs type",
+			capabilityFsType: " xfs ",
+			wantFsType:       "xfs",
+		},
+		{
+			name:          "falls back to volume context fs type",
+			volumeContext: map[string]string{"fsType": "xfs"},
+			wantFsType:    "xfs",
+		},
+		{
+			name:             "prefers CSI mount fs type over volume context",
+			capabilityFsType: "xfs",
+			volumeContext:    map[string]string{"fsType": "ext4"},
+			wantFsType:       "xfs",
+		},
+		{
+			name:       "defaults to ext4",
+			wantFsType: "ext4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns, _, _ := newTestNodeServer(t)
+			stagingTargetPath := t.TempDir()
+
+			originalConnect := iscsilibConnect
+			iscsilibConnect = func(c *iscsilib.Connector) (string, error) {
+				c.MountTargetDevice = &iscsilib.Device{Name: "sdb", Type: "disk"}
+				return "/dev/sdb", nil
+			}
+			t.Cleanup(func() { iscsilibConnect = originalConnect })
+
+			var gotSource, gotTarget, gotFsType string
+			var gotOptions []string
+			originalFormatAndMount := formatAndMount
+			formatAndMount = func(m *mount.SafeFormatAndMount, source, target, fsType string, options []string) error {
+				gotSource = source
+				gotTarget = target
+				gotFsType = fsType
+				gotOptions = append([]string(nil), options...)
+				return nil
+			}
+			t.Cleanup(func() { formatAndMount = originalFormatAndMount })
+
+			resp, err := ns.NodeStageVolume(context.Background(), &csi.NodeStageVolumeRequest{
+				VolumeId:          "test-vol",
+				StagingTargetPath: stagingTargetPath,
+				VolumeCapability: &csi.VolumeCapability{
+					AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+					AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{
+						FsType: tt.capabilityFsType,
+					}},
+				},
+				PublishContext: map[string]string{
+					"targetPortal": "10.0.0.1:3260",
+					"iqn":          "iqn.2024-01.com.example:test-volume",
+					"lun":          "0",
+				},
+				VolumeContext: tt.volumeContext,
+			})
+
+			require.NoError(t, err)
+			assert.NotNil(t, resp)
+			assert.Equal(t, "/dev/sdb", gotSource)
+			assert.Equal(t, stagingTargetPath, gotTarget)
+			assert.Equal(t, tt.wantFsType, gotFsType)
+			for _, opt := range tt.wantOptions {
+				assert.Contains(t, gotOptions, opt)
+			}
+		})
+	}
+}
+
 func TestNodeStageVolume_NFS(t *testing.T) {
 	ns, _, mockMount := newTestNodeServer(t)
 	stagingTargetPath := t.TempDir()
@@ -546,6 +636,57 @@ func TestNodePublishVolume_ReadOnly(t *testing.T) {
 	assert.Equal(t, targetPath, mockMount.formatAndMounts[0].target)
 	assert.Contains(t, mockMount.formatAndMounts[0].options, "bind")
 	assert.Contains(t, mockMount.formatAndMounts[0].options, "ro")
+}
+
+func TestNodePublishVolume_RecoverStagingUsesVolumeCapabilityFsType(t *testing.T) {
+	ns, _, mockMount := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+	targetPath := t.TempDir()
+	conn := &iscsilib.Connector{
+		MountTargetDevice: &iscsilib.Device{Name: "sdb", Type: "disk"},
+	}
+
+	originalGetConnector := getConnectorFromFile
+	getConnectorFromFile = func(filePath string) (*iscsilib.Connector, error) {
+		assert.Equal(t, stageConnectorFile(stagingTargetPath), filePath)
+		return conn, nil
+	}
+	t.Cleanup(func() { getConnectorFromFile = originalGetConnector })
+
+	var gotSource, gotTarget, gotFsType string
+	originalFormatAndMount := formatAndMount
+	formatAndMount = func(m *mount.SafeFormatAndMount, source, target, fsType string, options []string) error {
+		gotSource = source
+		gotTarget = target
+		gotFsType = fsType
+		return nil
+	}
+	t.Cleanup(func() { formatAndMount = originalFormatAndMount })
+
+	resp, err := ns.NodePublishVolume(context.Background(), &csi.NodePublishVolumeRequest{
+		VolumeId:          "test-vol",
+		TargetPath:        targetPath,
+		StagingTargetPath: stagingTargetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{FsType: "xfs"}},
+		},
+		PublishContext: map[string]string{
+			"targetPortal": "10.0.0.1:3260",
+			"iqn":          "iqn.2024-01.com.example:test-volume",
+			"lun":          "0",
+		},
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, conn.MountTargetDevice.GetPath(), gotSource)
+	assert.Equal(t, stagingTargetPath, gotTarget)
+	assert.Equal(t, "xfs", gotFsType)
+	require.Len(t, mockMount.formatAndMounts, 1)
+	assert.Equal(t, stagingTargetPath, mockMount.formatAndMounts[0].source)
+	assert.Equal(t, targetPath, mockMount.formatAndMounts[0].target)
+	assert.Contains(t, mockMount.formatAndMounts[0].options, "bind")
 }
 
 func TestNodePublishVolume_FileShareBind(t *testing.T) {


### PR DESCRIPTION
Don't cleanup multi arch images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and developer guidance with expanded subsections for build, test, and Docker operations
  * Refreshed Helm OCI/GHCR chart examples with version selection and upgrade/uninstall instructions

* **Tests**
  * Added test coverage for filesystem type selection and recovery scenarios in staging operations

* **Chores**
  * Enhanced container artifact cleanup with improved digest protection
  * Added release token validation to prevent failed deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->