### PR TITLE
fix: Create secret for credentials for WinRM client

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,33 @@ Override any value from [`values.yaml`](./chart/csi-driver-for-windows-storage-s
 image:
   tag: 1.0.0
   pullPolicy: Always
+
+winrm:
+  host: win-storage.lab.local
+  port: 5986
+  tls: true
+  insecure: true
+  existingSecret: csi-driver-winrm
+```
+
+When using `winrm.existingSecret`, create the WinRM credentials secret before installing:
+
+```sh
+kubectl -n kube-system create secret generic csi-driver-winrm \
+  --from-literal=WINRM_USER=csi-winrm-test \
+  --from-literal=WINRM_PASSWORD='<password>'
+```
+
+Alternatively, let the chart create the credentials secret:
+
+```yaml
+winrm:
+  host: win-storage.lab.local
+  port: 5986
+  tls: true
+  insecure: true
+  user: csi-winrm-test
+  password: "<password>"
 ```
 
 ```sh

--- a/chart/csi-driver-for-windows-storage-server/templates/_helpers.tpl
+++ b/chart/csi-driver-for-windows-storage-server/templates/_helpers.tpl
@@ -1,12 +1,26 @@
 {{/*
+Create the name of the controller resources
+*/}}
+{{- define "csi-driver-for-windows-storage-server.controllerName" -}}
+{{- printf "%s-controller" ((include "csi-driver-for-windows-storage-server.fullname" .) | trunc 52 | trimSuffix "-") }}
+{{- end }}
+
+{{/*
 Create the name of the controller service account to use
 */}}
 {{- define "csi-driver-for-windows-storage-server.controllerServiceAccountName" -}}
 {{- if .Values.controller.serviceAccount.create }}
-{{- default (printf "%s-controller" (include "csi-driver-for-windows-storage-server.fullname" .)) .Values.controller.serviceAccount.name }}
+{{- default (include "csi-driver-for-windows-storage-server.controllerName" .) .Values.controller.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.controller.serviceAccount.name }}
 {{- end }}
+{{- end }}
+
+{{/*
+Create the name of the node resources
+*/}}
+{{- define "csi-driver-for-windows-storage-server.nodeName" -}}
+{{- printf "%s-node" ((include "csi-driver-for-windows-storage-server.fullname" .) | trunc 58 | trimSuffix "-") }}
 {{- end }}
 
 {{/*
@@ -14,11 +28,19 @@ Create the name of the node service account to use
 */}}
 {{- define "csi-driver-for-windows-storage-server.nodeServiceAccountName" -}}
 {{- if .Values.node.serviceAccount.create }}
-{{- default (printf "%s-node" (include "csi-driver-for-windows-storage-server.fullname" .)) .Values.node.serviceAccount.name }}
+{{- default (include "csi-driver-for-windows-storage-server.nodeName" .) .Values.node.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.node.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the WinRM credentials secret to use
+*/}}
+{{- define "csi-driver-for-windows-storage-server.winrmSecretName" -}}
+{{- default (printf "%s-winrm" ((include "csi-driver-for-windows-storage-server.fullname" .) | trunc 57 | trimSuffix "-")) .Values.winrm.existingSecret }}
+{{- end }}
+
 {{/*
 Expand the name of the csi-driver-for-windows-storage-server chart.
 */}}

--- a/chart/csi-driver-for-windows-storage-server/templates/clusterrole-controller.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/clusterrole-controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "csi-driver-for-windows-storage-server.fullname" . }}-controller
+  name: {{ include "csi-driver-for-windows-storage-server.controllerName" . }}
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes", "persistentvolumeclaims", "nodes", "events", "secrets"]

--- a/chart/csi-driver-for-windows-storage-server/templates/clusterrole-node.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/clusterrole-node.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "csi-driver-for-windows-storage-server.fullname" . }}-node
+  name: {{ include "csi-driver-for-windows-storage-server.nodeName" . }}
 rules:
   - apiGroups: [""]
     resources: ["nodes", "pods", "secrets", "events"]

--- a/chart/csi-driver-for-windows-storage-server/templates/clusterrolebinding-controller.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/clusterrolebinding-controller.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "csi-driver-for-windows-storage-server.fullname" . }}-controller
+  name: {{ include "csi-driver-for-windows-storage-server.controllerName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "csi-driver-for-windows-storage-server.fullname" . }}-controller
+  name: {{ include "csi-driver-for-windows-storage-server.controllerName" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "csi-driver-for-windows-storage-server.controllerServiceAccountName" . }}

--- a/chart/csi-driver-for-windows-storage-server/templates/clusterrolebinding-node.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/clusterrolebinding-node.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "csi-driver-for-windows-storage-server.fullname" . }}-node
+  name: {{ include "csi-driver-for-windows-storage-server.nodeName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "csi-driver-for-windows-storage-server.fullname" . }}-node
+  name: {{ include "csi-driver-for-windows-storage-server.nodeName" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "csi-driver-for-windows-storage-server.nodeServiceAccountName" . }}

--- a/chart/csi-driver-for-windows-storage-server/templates/daemonset-node.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/daemonset-node.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "csi-driver-for-windows-storage-server.fullname" . }}-node
+  name: {{ include "csi-driver-for-windows-storage-server.nodeName" . }}
   labels:
     {{- include "csi-driver-for-windows-storage-server.labels" . | nindent 4 }}
 spec:

--- a/chart/csi-driver-for-windows-storage-server/templates/deployment-controller.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/deployment-controller.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "csi-driver-for-windows-storage-server.fullname" . }}-controller
+  name: {{ include "csi-driver-for-windows-storage-server.controllerName" . }}
   labels:
     {{- include "csi-driver-for-windows-storage-server.labels" . | nindent 4 }}
 spec:
@@ -24,6 +24,32 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: "unix:///csi/csi.sock"
+            - name: WINRM_HOST
+              value: {{ required "winrm.host is required" .Values.winrm.host | quote }}
+            - name: WINRM_PORT
+              value: {{ .Values.winrm.port | quote }}
+            - name: WINRM_TLS
+              value: {{ .Values.winrm.tls | quote }}
+            - name: WINRM_INSECURE
+              value: {{ .Values.winrm.insecure | quote }}
+            - name: WINRM_AUTH
+              value: {{ .Values.winrm.auth | quote }}
+            - name: WINRM_TIMEOUT
+              value: {{ .Values.winrm.timeout | quote }}
+            {{- if .Values.winrm.psImport }}
+            - name: WINRM_PS_IMPORT
+              value: {{ .Values.winrm.psImport | quote }}
+            {{- end }}
+            - name: WINRM_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "csi-driver-for-windows-storage-server.winrmSecretName" . }}
+                  key: WINRM_USER
+            - name: WINRM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "csi-driver-for-windows-storage-server.winrmSecretName" . }}
+                  key: WINRM_PASSWORD
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/chart/csi-driver-for-windows-storage-server/templates/secret-winrm.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/secret-winrm.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.winrm.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "csi-driver-for-windows-storage-server.winrmSecretName" . }}
+  labels:
+    {{- include "csi-driver-for-windows-storage-server.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  WINRM_USER: {{ required "winrm.user is required when winrm.existingSecret is not set" .Values.winrm.user | quote }}
+  WINRM_PASSWORD: {{ required "winrm.password is required when winrm.existingSecret is not set" .Values.winrm.password | quote }}
+{{- end }}

--- a/chart/csi-driver-for-windows-storage-server/values.yaml
+++ b/chart/csi-driver-for-windows-storage-server/values.yaml
@@ -25,3 +25,19 @@ fullnameOverride: ""
 
 # If you need to pull images from a private registry, set this
 imagePullSecrets: []
+
+winrm:
+  host: ""
+  port: 5986
+  tls: true
+  insecure: true
+  auth: basic
+  timeout: 60s
+  psImport: ""
+
+  # Use an existing Secret with WINRM_USER and WINRM_PASSWORD keys.
+  existingSecret: ""
+
+  # When existingSecret is empty, the chart creates a Secret using winrm.user and winrm.password.
+  user: ""
+  password: ""


### PR DESCRIPTION
Create secret for credentials for WinRM client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows Remote Management (WinRM) support: host, port, TLS, auth, timeout, and optional PS import.
  * Option to use an existing WinRM secret or let the chart generate credentials.

* **Refactor**
  * Controller/node resource names are now derived with truncation rules, affecting resulting Kubernetes resource names.

* **Documentation**
  * README updated with YAML and shell examples for WinRM and secret handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->