### PR TITLE
fix: Update helm chart for nfs and smb

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,28 @@ CSI node ID. When a pod moves to another node, Kubernetes attach calls cause the
 controller to remove the old node initiator from the Windows target and add the
 new node initiator before the node logs in.
 
+#### Optional: iSCSI CHAP
+
+iSCSI CHAP uses one Secret shared across the controller and node paths. The
+controller uses it to configure Windows target CHAP and reverse CHAP; the node
+uses it to configure Linux open-iscsi discovery and login.
+
+```yaml
+parameters:
+  csi.storage.k8s.io/provisioner-secret-name: "iscsi-chap"
+  csi.storage.k8s.io/provisioner-secret-namespace: "${pvc.namespace}"
+  csi.storage.k8s.io/controller-publish-secret-name: "iscsi-chap"
+  csi.storage.k8s.io/controller-publish-secret-namespace: "${pvc.namespace}"
+  csi.storage.k8s.io/node-stage-secret-name: "iscsi-chap"
+  csi.storage.k8s.io/node-stage-secret-namespace: "${pvc.namespace}"
+```
+
+The Windows target side is configured from `node.session.auth.username` and
+`node.session.auth.password`. Mutual CHAP uses
+`node.session.auth.username_in` and `node.session.auth.password_in` for reverse
+CHAP. Discovery CHAP keys configure Linux open-iscsi discovery; Windows Server
+iSCSI target CHAP is configured per target.
+
 ### Windows Server Bootstrap
 
 Run the PowerShell setup script from an elevated PowerShell session on the Windows Server:
@@ -328,14 +350,37 @@ make image
 
 #### 3. Install the driver manifests:
 
+The manifest installer creates the controller WinRM Secret from environment
+variables when `Secret/kube-system/csi-driver-winrm` does not already exist:
+
 ```sh
+export WINRM_HOST=win-storage.lab.local
+export WINRM_USER=csi-winrm-test
+export WINRM_PASSWORD='<password>'
+# Optional: override the PowerShell module import used by the WinRM backend.
+# export WINRM_PS_IMPORT='Import-Module IscsiTarget'
+
 ./deploy/install-driver.sh master local
 ```
+
+For static, pre-provisioned volumes where Windows storage is already configured,
+install only the Linux node side:
+
+```sh
+./deploy/install-driver.sh master local --node-only
+```
+
+Node-only mode skips the controller, WinRM Secret, and Windows-side setup. It
+also disables CSI attach for iSCSI, so static iSCSI PVs must include
+`targetPortal`, `iqn` or `targetIQN`, and `lun` in `volumeAttributes`, or encode
+those values in `volumeHandle` as an `iscsi://.../lun/<n>` URI. The Windows
+iSCSI target must already allow every Linux node initiator that may run the pod.
 
 #### 4. Check the driver pods:
 
 ```sh
-kubectl -n kube-system get pod -o wide -l app=csi-for-windows-server-node
+kubectl -n kube-system get pods -o wide \
+  -l app
 ```
 
 #### 5. Uninstall the driver:
@@ -359,12 +404,29 @@ The chart is published as an OCI artifact to GHCR at `oci://ghcr.io/taliesins/he
 
 WinRM connection details are required for the controller. Set `winrm.host` to the Windows storage server DNS name or IP address reachable from the Kubernetes cluster, and set `winrm.user` / `winrm.password` to the account configured by the Windows bootstrap script.
 
+By default, the chart deploys controller, node, and CSIDriver objects for all
+five drivers: iSCSI, NFS, NFS VHDX, SMB, and SMB VHDX. Disable individual
+drivers with `drivers.<name>.enabled=false` when you only need a subset.
+For static, pre-provisioned volumes, set `nodeOnly=true` to skip all controller
+and WinRM setup and install only the Linux node side.
+
 ```sh
 helm upgrade --install --create-namespace csi-driver-for-windows-storage-server oci://ghcr.io/taliesins/helm/csi-driver-for-windows-storage-server -n=kube-system \
   --set winrm.host=win-storage.lab.local \
   --set winrm.user=csi-winrm-test \
   --set-string winrm.password='<password>'
 ```
+
+Node-only Helm install:
+
+```sh
+helm upgrade --install --create-namespace csi-driver-for-windows-storage-server oci://ghcr.io/taliesins/helm/csi-driver-for-windows-storage-server -n=kube-system \
+  --set nodeOnly=true
+```
+
+In node-only mode, dynamic provisioning is disabled because no controller is
+running. Static iSCSI PVs must point at an existing Windows target and LUN, and
+the Windows target must already permit the Linux node initiators or use CHAP.
 
 #### 2. Specify a version
 

--- a/chart/csi-driver-for-windows-storage-server/templates/NOTES.txt
+++ b/chart/csi-driver-for-windows-storage-server/templates/NOTES.txt
@@ -1,13 +1,23 @@
 Thank you for installing the csi-driver-for-windows-storage-server Helm chart!
 
 Your CSI driver has been deployed with:
-- Controller Deployment (cluster-wide volume operations)
-- Node DaemonSet (runs on every node for attach/mount)
-- CSIDriver attach enabled, so pod moves update Windows iSCSI target initiators
+{{- if .Values.nodeOnly }}
+- Node-only mode enabled: Windows-side controller configuration was skipped
+- Node DaemonSets for each enabled CSI driver
+- CSIDrivers with attach disabled, including iSCSI, for static pre-provisioned volumes
+{{- else }}
+- Controller Deployments for each enabled CSI driver
+- Node DaemonSets for each enabled CSI driver
+- CSIDriver attach enabled for iSCSI, so pod moves update Windows iSCSI target initiators
+{{- end }}
 
 Key resources created:
+{{- if .Values.nodeOnly }}
+- ServiceAccount, ClusterRole, and ClusterRoleBinding for node pods
+{{- else }}
 - ServiceAccounts: separate for controller and node
 - ClusterRoles and ClusterRoleBindings for least-privilege RBAC
+{{- end }}
 
 Each Linux node that uses iSCSI must have a stable open-iscsi initiator name at:
   {{ .Values.node.initiatorNamePath }}
@@ -15,17 +25,21 @@ Each Linux node that uses iSCSI must have a stable open-iscsi initiator name at:
 To verify the deployment:
 
 1. Check controller pod status:
-  kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+{{- if .Values.nodeOnly }}
+  # skipped in node-only mode
+{{- else }}
+  kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=controller -n {{ .Release.Namespace }}
+{{- end }}
 
-2. Check node pods (should be one per node):
-  kubectl get daemonset {{ include "csi-driver-for-windows-storage-server.nodeName" . }} -n {{ .Release.Namespace }}
+2. Check node daemonsets:
+  kubectl get daemonset -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=node -n {{ .Release.Namespace }}
 
 3. Check RBAC and ServiceAccounts:
-  kubectl get serviceaccounts,clusterroles,clusterrolebindings -n {{ .Release.Namespace }} | grep iscsi
+  kubectl get serviceaccounts,clusterroles,clusterrolebindings -n {{ .Release.Namespace }} | grep csi-driver-for-windows-storage-server
 
 4. To see logs for troubleshooting:
-  kubectl logs deployment/{{ include "csi-driver-for-windows-storage-server.controllerName" . }} -n {{ .Release.Namespace }}
-  kubectl logs daemonset/{{ include "csi-driver-for-windows-storage-server.nodeName" . }} -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=controller -n {{ .Release.Namespace }}
+  kubectl logs -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=node -n {{ .Release.Namespace }}
 
 To use the driver, create a StorageClass referencing this CSI driver and then create PVCs as needed. See the examples/ directory for sample manifests.
 

--- a/chart/csi-driver-for-windows-storage-server/templates/_helpers.tpl
+++ b/chart/csi-driver-for-windows-storage-server/templates/_helpers.tpl
@@ -24,6 +24,29 @@ Create the name of the node resources
 {{- end }}
 
 {{/*
+Create the name of a controller Deployment for one CSI driver.
+*/}}
+{{- define "csi-driver-for-windows-storage-server.driverControllerName" -}}
+{{- printf "%s-%s-controller" ((include "csi-driver-for-windows-storage-server.fullname" .root) | trunc 44 | trimSuffix "-") .key | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create the name of a node DaemonSet for one CSI driver.
+*/}}
+{{- define "csi-driver-for-windows-storage-server.driverNodeName" -}}
+{{- printf "%s-%s-node" ((include "csi-driver-for-windows-storage-server.fullname" .root) | trunc 50 | trimSuffix "-") .key | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Labels/selectors scoped to one rendered CSI driver instance.
+*/}}
+{{- define "csi-driver-for-windows-storage-server.driverSelectorLabels" -}}
+{{ include "csi-driver-for-windows-storage-server.selectorLabels" .root }}
+app.kubernetes.io/csi-driver: {{ .key | quote }}
+app.kubernetes.io/component: {{ .component | quote }}
+{{- end }}
+
+{{/*
 Create the name of the node service account to use
 */}}
 {{- define "csi-driver-for-windows-storage-server.nodeServiceAccountName" -}}

--- a/chart/csi-driver-for-windows-storage-server/templates/clusterrole-controller.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/clusterrole-controller.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeOnly }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -20,3 +21,4 @@ rules:
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
   {{- end }}
+{{- end }}

--- a/chart/csi-driver-for-windows-storage-server/templates/clusterrolebinding-controller.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/clusterrolebinding-controller.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.nodeOnly }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +11,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "csi-driver-for-windows-storage-server.controllerServiceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/csi-driver-for-windows-storage-server/templates/csidriver.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/csidriver.yaml
@@ -1,9 +1,15 @@
+{{- $root := . -}}
+{{- range $key, $driver := .Values.drivers }}
+{{- if $driver.enabled }}
+---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
-  name: iscsi.csi.windows.microsoft.com
+  name: {{ $driver.name }}
 spec:
-  attachRequired: true
+  attachRequired: {{ and (not $root.Values.nodeOnly) $driver.attachRequired }}
   volumeLifecycleModes:
     - Persistent
     - Ephemeral
+{{- end }}
+{{- end }}

--- a/chart/csi-driver-for-windows-storage-server/templates/daemonset-node.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/daemonset-node.yaml
@@ -1,44 +1,52 @@
+{{- $root := . -}}
+{{- range $key, $driver := .Values.drivers }}
+{{- if $driver.enabled }}
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "csi-driver-for-windows-storage-server.nodeName" . }}
+  name: {{ include "csi-driver-for-windows-storage-server.driverNodeName" (dict "root" $root "key" $key) }}
   labels:
-    {{- include "csi-driver-for-windows-storage-server.labels" . | nindent 4 }}
+    {{- include "csi-driver-for-windows-storage-server.labels" $root | nindent 4 }}
+    app.kubernetes.io/csi-driver: {{ $key | quote }}
+    app.kubernetes.io/component: "node"
 spec:
   selector:
     matchLabels:
-      {{- include "csi-driver-for-windows-storage-server.selectorLabels" . | nindent 6 }}
+      {{- include "csi-driver-for-windows-storage-server.driverSelectorLabels" (dict "root" $root "key" $key "component" "node") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "csi-driver-for-windows-storage-server.labels" . | nindent 8 }}
+        {{- include "csi-driver-for-windows-storage-server.labels" $root | nindent 8 }}
+        app.kubernetes.io/csi-driver: {{ $key | quote }}
+        app.kubernetes.io/component: "node"
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       nodeSelector:
         kubernetes.io/os: linux
-      serviceAccountName: {{ include "csi-driver-for-windows-storage-server.nodeServiceAccountName" . }}
+      serviceAccountName: {{ include "csi-driver-for-windows-storage-server.nodeServiceAccountName" $root }}
       containers:
         - name: liveness-probe
-          image: {{ .Values.sidecars.livenessProbe.image | quote }}
+          image: {{ $root.Values.sidecars.livenessProbe.image | quote }}
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
-            - --health-port=29753
-            - --v={{ .Values.sidecars.logLevel }}
+            - --health-port={{ $driver.livenessPort }}
+            - --v={{ $root.Values.sidecars.logLevel }}
           ports:
-            - containerPort: 29753
+            - containerPort: {{ $driver.livenessPort }}
               name: healthz
               protocol: TCP
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
         - name: node-driver-registrar
-          image: {{ .Values.sidecars.nodeDriverRegistrar.image | quote }}
+          image: {{ $root.Values.sidecars.nodeDriverRegistrar.image | quote }}
           args:
-            - --v={{ .Values.sidecars.logLevel }}
+            - --v={{ $root.Values.sidecars.logLevel }}
             - --csi-address=/csi/csi.sock
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/iscsi.csi.windows.microsoft.com/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/{{ $driver.name }}/csi.sock
           env:
             - name: KUBE_NODE_NAME
               valueFrom:
@@ -56,14 +64,25 @@ spec:
               add:
                 - SYS_ADMIN
             allowPrivilegeEscalation: true
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ $root.Values.image.repository }}:{{ $root.Values.image.tag | default $root.Chart.AppVersion }}"
+          imagePullPolicy: {{ $root.Values.image.pullPolicy }}
           args:
             - --endpoint=$(CSI_ENDPOINT)
-            - --nodeid-file=/host{{ .Values.node.initiatorNamePath }}
+            {{- if $driver.needsIscsi }}
+            - --nodeid-file=/host{{ $root.Values.node.initiatorNamePath }}
+            {{- else }}
+            - --nodeid=$(NODE_ID)
+            {{- end }}
             - --mode=node
-            - --v={{ .Values.sidecars.logLevel }}
+            - --drivername={{ $driver.name }}
+            - --v={{ $root.Values.sidecars.logLevel }}
           env:
+            {{- if not $driver.needsIscsi }}
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            {{- end }}
             - name: CSI_ENDPOINT
               value: "unix:///csi/csi.sock"
             - name: CSI_DRIVER_RUN_DIR
@@ -74,20 +93,24 @@ spec:
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet
               mountPropagation: Bidirectional
+            {{- if $driver.needsIscsi }}
             - name: host-dev
               mountPath: /dev
+            {{- end }}
             - name: host-root
               mountPath: /host
               mountPropagation: HostToContainer
+            {{- if $driver.needsIscsi }}
             - name: chroot-iscsiadm
               mountPath: /sbin/iscsiadm
               subPath: iscsiadm
-            - name: iscsi-csi-run-dir
-              mountPath: /var/run/iscsi.csi.windows.microsoft.com
+            {{- end }}
+            - name: csi-run-dir
+              mountPath: /var/run/{{ $driver.name }}
       volumes:
         - name: socket-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/iscsi.csi.windows.microsoft.com
+            path: /var/lib/kubelet/plugins/{{ $driver.name }}
             type: DirectoryOrCreate
         - name: mountpoint-dir
           hostPath:
@@ -97,28 +120,38 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins_registry
             type: DirectoryOrCreate
+        {{- if $driver.needsIscsi }}
         - name: host-dev
           hostPath:
             path: /dev
+        {{- end }}
         - name: host-root
           hostPath:
             path: /
             type: Directory
+        {{- if $driver.needsIscsi }}
         - name: chroot-iscsiadm
           configMap:
             defaultMode: 0555
-            name: {{ include "csi-driver-for-windows-storage-server.nodeName" . }}-iscsiadm
-        - name: iscsi-csi-run-dir
+            name: {{ include "csi-driver-for-windows-storage-server.driverNodeName" (dict "root" $root "key" $key) }}-iscsiadm
+        {{- end }}
+        - name: csi-run-dir
           hostPath:
-            path: /var/run/iscsi.csi.windows.microsoft.com
+            path: /var/run/{{ $driver.name }}
             type: DirectoryOrCreate
+{{- end }}
+{{- end }}
+{{- $iscsi := index .Values.drivers "iscsi" -}}
+{{- if and $iscsi $iscsi.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "csi-driver-for-windows-storage-server.nodeName" . }}-iscsiadm
+  name: {{ include "csi-driver-for-windows-storage-server.driverNodeName" (dict "root" . "key" "iscsi") }}-iscsiadm
   labels:
     {{- include "csi-driver-for-windows-storage-server.labels" . | nindent 4 }}
+    app.kubernetes.io/csi-driver: "iscsi"
+    app.kubernetes.io/component: "node"
 data:
   iscsiadm: |
     #!/bin/sh
@@ -133,3 +166,4 @@ data:
     else
       chroot /host iscsiadm "$@"
     fi
+{{- end }}

--- a/chart/csi-driver-for-windows-storage-server/templates/daemonset-node.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/daemonset-node.yaml
@@ -141,16 +141,16 @@ spec:
             type: DirectoryOrCreate
 {{- end }}
 {{- end }}
-{{- $iscsi := index .Values.drivers "iscsi" -}}
-{{- if and $iscsi $iscsi.enabled }}
+{{- range $key, $driver := .Values.drivers }}
+{{- if and $driver.enabled $driver.needsIscsi }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "csi-driver-for-windows-storage-server.driverNodeName" (dict "root" . "key" "iscsi") }}-iscsiadm
+  name: {{ include "csi-driver-for-windows-storage-server.driverNodeName" (dict "root" $root "key" $key) }}-iscsiadm
   labels:
-    {{- include "csi-driver-for-windows-storage-server.labels" . | nindent 4 }}
-    app.kubernetes.io/csi-driver: "iscsi"
+    {{- include "csi-driver-for-windows-storage-server.labels" $root | nindent 4 }}
+    app.kubernetes.io/csi-driver: {{ $key | quote }}
     app.kubernetes.io/component: "node"
 data:
   iscsiadm: |
@@ -166,4 +166,5 @@ data:
     else
       chroot /host iscsiadm "$@"
     fi
+{{- end }}
 {{- end }}

--- a/chart/csi-driver-for-windows-storage-server/templates/deployment-controller.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/deployment-controller.yaml
@@ -30,6 +30,20 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --v={{ $root.Values.sidecars.logLevel }}
+            {{- if gt (int $root.Values.controller.replicas) 1 }}
+            - --leader-election=true
+            - --leader-election-namespace=$(POD_NAMESPACE)
+            - --leader-election-lease-duration={{ $root.Values.controller.leaderElection.leaseDuration }}
+            - --leader-election-renew-deadline={{ $root.Values.controller.leaderElection.renewDeadline }}
+            - --leader-election-retry-period={{ $root.Values.controller.leaderElection.retryPeriod }}
+            {{- end }}
+          {{- if gt (int $root.Values.controller.replicas) 1 }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -39,6 +53,20 @@ spec:
           args:
             - --csi-address=/csi/csi.sock
             - --v={{ $root.Values.sidecars.logLevel }}
+            {{- if gt (int $root.Values.controller.replicas) 1 }}
+            - --leader-election=true
+            - --leader-election-namespace=$(POD_NAMESPACE)
+            - --leader-election-lease-duration={{ $root.Values.controller.leaderElection.leaseDuration }}
+            - --leader-election-renew-deadline={{ $root.Values.controller.leaderElection.renewDeadline }}
+            - --leader-election-retry-period={{ $root.Values.controller.leaderElection.retryPeriod }}
+            {{- end }}
+          {{- if gt (int $root.Values.controller.replicas) 1 }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/chart/csi-driver-for-windows-storage-server/templates/deployment-controller.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/deployment-controller.yaml
@@ -1,44 +1,55 @@
+{{- if not .Values.nodeOnly }}
+{{- $root := . -}}
+{{- range $key, $driver := .Values.drivers }}
+{{- if $driver.enabled }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "csi-driver-for-windows-storage-server.controllerName" . }}
+  name: {{ include "csi-driver-for-windows-storage-server.driverControllerName" (dict "root" $root "key" $key) }}
   labels:
-    {{- include "csi-driver-for-windows-storage-server.labels" . | nindent 4 }}
+    {{- include "csi-driver-for-windows-storage-server.labels" $root | nindent 4 }}
+    app.kubernetes.io/csi-driver: {{ $key | quote }}
+    app.kubernetes.io/component: "controller"
 spec:
-  replicas: {{ .Values.controller.replicas }}
+  replicas: {{ $root.Values.controller.replicas }}
   selector:
     matchLabels:
-      {{- include "csi-driver-for-windows-storage-server.selectorLabels" . | nindent 6 }}
+      {{- include "csi-driver-for-windows-storage-server.driverSelectorLabels" (dict "root" $root "key" $key "component" "controller") | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "csi-driver-for-windows-storage-server.labels" . | nindent 8 }}
+        {{- include "csi-driver-for-windows-storage-server.labels" $root | nindent 8 }}
+        app.kubernetes.io/csi-driver: {{ $key | quote }}
+        app.kubernetes.io/component: "controller"
     spec:
-      serviceAccountName: {{ include "csi-driver-for-windows-storage-server.controllerServiceAccountName" . }}
+      serviceAccountName: {{ include "csi-driver-for-windows-storage-server.controllerServiceAccountName" $root }}
       containers:
         - name: csi-provisioner
-          image: {{ .Values.sidecars.provisioner.image | quote }}
+          image: {{ $root.Values.sidecars.provisioner.image | quote }}
           args:
             - --csi-address=/csi/csi.sock
-            - --v={{ .Values.sidecars.logLevel }}
+            - --v={{ $root.Values.sidecars.logLevel }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        {{- if $driver.attachRequired }}
         - name: csi-attacher
-          image: {{ .Values.sidecars.attacher.image | quote }}
+          image: {{ $root.Values.sidecars.attacher.image | quote }}
           args:
             - --csi-address=/csi/csi.sock
-            - --v={{ .Values.sidecars.logLevel }}
+            - --v={{ $root.Values.sidecars.logLevel }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        {{- end }}
         - name: liveness-probe
-          image: {{ .Values.sidecars.livenessProbe.image | quote }}
+          image: {{ $root.Values.sidecars.livenessProbe.image | quote }}
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
             - --health-port=29752
-            - --v={{ .Values.sidecars.logLevel }}
+            - --v={{ $root.Values.sidecars.logLevel }}
           ports:
             - containerPort: 29752
               name: healthz
@@ -47,24 +58,25 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: controller-driver
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ $root.Values.image.repository }}:{{ $root.Values.image.tag | default $root.Chart.AppVersion }}"
+          imagePullPolicy: {{ $root.Values.image.pullPolicy }}
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --mode=controller
-            {{- if gt (int .Values.controller.replicas) 1 }}
+            - --drivername={{ $driver.name }}
+            {{- if gt (int $root.Values.controller.replicas) 1 }}
             - --leader-election=true
-            - --leader-election-name={{ include "csi-driver-for-windows-storage-server.controllerName" . }}
+            - --leader-election-name={{ include "csi-driver-for-windows-storage-server.driverControllerName" (dict "root" $root "key" $key) }}
             - --leader-election-namespace=$(POD_NAMESPACE)
             - --leader-election-identity=$(POD_NAME)
-            - --leader-election-lease-duration={{ .Values.controller.leaderElection.leaseDuration }}
-            - --leader-election-renew-deadline={{ .Values.controller.leaderElection.renewDeadline }}
-            - --leader-election-retry-period={{ .Values.controller.leaderElection.retryPeriod }}
+            - --leader-election-lease-duration={{ $root.Values.controller.leaderElection.leaseDuration }}
+            - --leader-election-renew-deadline={{ $root.Values.controller.leaderElection.renewDeadline }}
+            - --leader-election-retry-period={{ $root.Values.controller.leaderElection.retryPeriod }}
             {{- end }}
           env:
             - name: CSI_ENDPOINT
               value: "unix:///csi/csi.sock"
-            {{- if gt (int .Values.controller.replicas) 1 }}
+            {{- if gt (int $root.Values.controller.replicas) 1 }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -74,12 +86,13 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             {{- end }}
-            {{- include "csi-driver-for-windows-storage-server.winrmEnv" . | nindent 12 }}
+            {{- include "csi-driver-for-windows-storage-server.winrmEnv" $root | nindent 12 }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
       volumes:
         - name: socket-dir
-          hostPath:
-            path: /var/lib/kubelet/plugins/csi-driver-for-windows-storage-server
-            type: DirectoryOrCreate
+          emptyDir: {}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/chart/csi-driver-for-windows-storage-server/templates/secret-winrm.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/secret-winrm.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.winrm.existingSecret }}
+{{- if and (not .Values.nodeOnly) (not .Values.winrm.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/csi-driver-for-windows-storage-server/templates/serviceaccount-controller.yaml
+++ b/chart/csi-driver-for-windows-storage-server/templates/serviceaccount-controller.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.controller.serviceAccount.create }}
+{{- if and (not .Values.nodeOnly) .Values.controller.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/chart/csi-driver-for-windows-storage-server/values.yaml
+++ b/chart/csi-driver-for-windows-storage-server/values.yaml
@@ -1,4 +1,6 @@
 # Controller-specific ServiceAccount
+nodeOnly: false
+
 controller:
   replicas: 1
   leaderElection:
@@ -19,6 +21,38 @@ node:
     automount: true
     annotations: {}
     name: ""
+
+drivers:
+  iscsi:
+    enabled: true
+    name: iscsi.csi.windows.microsoft.com
+    attachRequired: true
+    needsIscsi: true
+    livenessPort: 29753
+  nfs:
+    enabled: true
+    name: nfs.csi.windows.microsoft.com
+    attachRequired: false
+    needsIscsi: false
+    livenessPort: 29754
+  nfs-vhdx:
+    enabled: true
+    name: nfs-vhdx.csi.windows.microsoft.com
+    attachRequired: false
+    needsIscsi: false
+    livenessPort: 29756
+  smb:
+    enabled: true
+    name: smb.csi.windows.microsoft.com
+    attachRequired: false
+    needsIscsi: false
+    livenessPort: 29755
+  smb-vhdx:
+    enabled: true
+    name: smb-vhdx.csi.windows.microsoft.com
+    attachRequired: false
+    needsIscsi: false
+    livenessPort: 29757
 
 sidecars:
   logLevel: 2

--- a/deploy/csi-driver-for-windows-storage-server-controller.yaml
+++ b/deploy/csi-driver-for-windows-storage-server-controller.yaml
@@ -11,8 +11,11 @@ metadata:
   name: csi-windows-storage-controller
 rules:
   - apiGroups: [""]
-    resources: ["persistentvolumes", "persistentvolumeclaims", "nodes", "events", "secrets"]
+    resources: ["persistentvolumes", "persistentvolumeclaims", "events"]
     verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes", "secrets"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]
     verbs: ["get", "update", "patch"]
@@ -84,7 +87,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: iscsi
-          image: gcr.io/k8s-staging-sig-storage/csiplugin:canary
+          image: ghcr.io/taliesins/csi-driver-for-windows-storage-server:0.2.0
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)
@@ -192,7 +195,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: nfs
-          image: gcr.io/k8s-staging-sig-storage/csiplugin:canary
+          image: ghcr.io/taliesins/csi-driver-for-windows-storage-server:0.2.0
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)
@@ -300,7 +303,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: nfs-vhdx
-          image: gcr.io/k8s-staging-sig-storage/csiplugin:canary
+          image: ghcr.io/taliesins/csi-driver-for-windows-storage-server:0.2.0
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)
@@ -408,7 +411,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: smb
-          image: gcr.io/k8s-staging-sig-storage/csiplugin:canary
+          image: ghcr.io/taliesins/csi-driver-for-windows-storage-server:0.2.0
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)
@@ -516,7 +519,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: smb-vhdx
-          image: gcr.io/k8s-staging-sig-storage/csiplugin:canary
+          image: ghcr.io/taliesins/csi-driver-for-windows-storage-server:0.2.0
           imagePullPolicy: IfNotPresent
           args:
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/csi-driver-for-windows-storage-server-controller.yaml
+++ b/deploy/csi-driver-for-windows-storage-server-controller.yaml
@@ -58,6 +58,9 @@ spec:
       containers:
         - name: csi-provisioner
           image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           args:
             - --csi-address=/csi/csi.sock
             - --v=2
@@ -66,6 +69,9 @@ spec:
               mountPath: /csi
         - name: csi-attacher
           image: registry.k8s.io/sig-storage/csi-attacher:v4.4.2
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           args:
             - --csi-address=/csi/csi.sock
             - --v=2
@@ -74,6 +80,9 @@ spec:
               mountPath: /csi
         - name: liveness-probe
           image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
@@ -174,6 +183,9 @@ spec:
       containers:
         - name: csi-provisioner
           image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           args:
             - --csi-address=/csi/csi.sock
             - --v=2
@@ -182,6 +194,9 @@ spec:
               mountPath: /csi
         - name: liveness-probe
           image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
@@ -282,6 +297,9 @@ spec:
       containers:
         - name: csi-provisioner
           image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           args:
             - --csi-address=/csi/csi.sock
             - --v=2
@@ -290,6 +308,9 @@ spec:
               mountPath: /csi
         - name: liveness-probe
           image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
@@ -390,6 +411,9 @@ spec:
       containers:
         - name: csi-provisioner
           image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           args:
             - --csi-address=/csi/csi.sock
             - --v=2
@@ -398,6 +422,9 @@ spec:
               mountPath: /csi
         - name: liveness-probe
           image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
@@ -498,6 +525,9 @@ spec:
       containers:
         - name: csi-provisioner
           image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           args:
             - --csi-address=/csi/csi.sock
             - --v=2
@@ -506,6 +536,9 @@ spec:
               mountPath: /csi
         - name: liveness-probe
           image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s

--- a/deploy/csi-driver-for-windows-storage-server-controller.yaml
+++ b/deploy/csi-driver-for-windows-storage-server-controller.yaml
@@ -1,0 +1,585 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-windows-storage-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-windows-storage-controller
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "persistentvolumeclaims", "nodes", "events", "secrets"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "volumeattachments", "csinodes", "csidrivers", "csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-windows-storage-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-windows-storage-controller
+subjects:
+  - kind: ServiceAccount
+    name: csi-windows-storage-controller
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csi-iscsi-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-iscsi-controller
+  template:
+    metadata:
+      labels:
+        app: csi-iscsi-controller
+    spec:
+      serviceAccountName: csi-windows-storage-controller
+      containers:
+        - name: csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+          args:
+            - --csi-address=/csi/csi.sock
+            - --v=2
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-attacher
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.4.2
+          args:
+            - --csi-address=/csi/csi.sock
+            - --v=2
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: liveness-probe
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=29752
+            - --v=2
+          ports:
+            - containerPort: 29752
+              name: healthz
+              protocol: TCP
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: iscsi
+          image: gcr.io/k8s-staging-sig-storage/csiplugin:canary
+          imagePullPolicy: IfNotPresent
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --mode=controller
+            - --drivername=iscsi.csi.windows.microsoft.com
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: WINRM_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_HOST
+            - name: WINRM_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PORT
+                  optional: true
+            - name: WINRM_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_TLS
+                  optional: true
+            - name: WINRM_INSECURE
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_INSECURE
+                  optional: true
+            - name: WINRM_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_AUTH
+                  optional: true
+            - name: WINRM_TIMEOUT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_TIMEOUT
+                  optional: true
+            - name: WINRM_PS_IMPORT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PS_IMPORT
+                  optional: true
+            - name: WINRM_USER
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_USER
+            - name: WINRM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PASSWORD
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csi-nfs-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-nfs-controller
+  template:
+    metadata:
+      labels:
+        app: csi-nfs-controller
+    spec:
+      serviceAccountName: csi-windows-storage-controller
+      containers:
+        - name: csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+          args:
+            - --csi-address=/csi/csi.sock
+            - --v=2
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: liveness-probe
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=29752
+            - --v=2
+          ports:
+            - containerPort: 29752
+              name: healthz
+              protocol: TCP
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: nfs
+          image: gcr.io/k8s-staging-sig-storage/csiplugin:canary
+          imagePullPolicy: IfNotPresent
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --mode=controller
+            - --drivername=nfs.csi.windows.microsoft.com
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: WINRM_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_HOST
+            - name: WINRM_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PORT
+                  optional: true
+            - name: WINRM_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_TLS
+                  optional: true
+            - name: WINRM_INSECURE
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_INSECURE
+                  optional: true
+            - name: WINRM_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_AUTH
+                  optional: true
+            - name: WINRM_TIMEOUT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_TIMEOUT
+                  optional: true
+            - name: WINRM_PS_IMPORT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PS_IMPORT
+                  optional: true
+            - name: WINRM_USER
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_USER
+            - name: WINRM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PASSWORD
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csi-nfs-vhdx-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-nfs-vhdx-controller
+  template:
+    metadata:
+      labels:
+        app: csi-nfs-vhdx-controller
+    spec:
+      serviceAccountName: csi-windows-storage-controller
+      containers:
+        - name: csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+          args:
+            - --csi-address=/csi/csi.sock
+            - --v=2
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: liveness-probe
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=29752
+            - --v=2
+          ports:
+            - containerPort: 29752
+              name: healthz
+              protocol: TCP
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: nfs-vhdx
+          image: gcr.io/k8s-staging-sig-storage/csiplugin:canary
+          imagePullPolicy: IfNotPresent
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --mode=controller
+            - --drivername=nfs-vhdx.csi.windows.microsoft.com
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: WINRM_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_HOST
+            - name: WINRM_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PORT
+                  optional: true
+            - name: WINRM_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_TLS
+                  optional: true
+            - name: WINRM_INSECURE
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_INSECURE
+                  optional: true
+            - name: WINRM_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_AUTH
+                  optional: true
+            - name: WINRM_TIMEOUT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_TIMEOUT
+                  optional: true
+            - name: WINRM_PS_IMPORT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PS_IMPORT
+                  optional: true
+            - name: WINRM_USER
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_USER
+            - name: WINRM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PASSWORD
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csi-smb-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-smb-controller
+  template:
+    metadata:
+      labels:
+        app: csi-smb-controller
+    spec:
+      serviceAccountName: csi-windows-storage-controller
+      containers:
+        - name: csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+          args:
+            - --csi-address=/csi/csi.sock
+            - --v=2
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: liveness-probe
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=29752
+            - --v=2
+          ports:
+            - containerPort: 29752
+              name: healthz
+              protocol: TCP
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: smb
+          image: gcr.io/k8s-staging-sig-storage/csiplugin:canary
+          imagePullPolicy: IfNotPresent
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --mode=controller
+            - --drivername=smb.csi.windows.microsoft.com
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: WINRM_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_HOST
+            - name: WINRM_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PORT
+                  optional: true
+            - name: WINRM_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_TLS
+                  optional: true
+            - name: WINRM_INSECURE
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_INSECURE
+                  optional: true
+            - name: WINRM_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_AUTH
+                  optional: true
+            - name: WINRM_TIMEOUT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_TIMEOUT
+                  optional: true
+            - name: WINRM_PS_IMPORT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PS_IMPORT
+                  optional: true
+            - name: WINRM_USER
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_USER
+            - name: WINRM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PASSWORD
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: csi-smb-vhdx-controller
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-smb-vhdx-controller
+  template:
+    metadata:
+      labels:
+        app: csi-smb-vhdx-controller
+    spec:
+      serviceAccountName: csi-windows-storage-controller
+      containers:
+        - name: csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+          args:
+            - --csi-address=/csi/csi.sock
+            - --v=2
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: liveness-probe
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=29752
+            - --v=2
+          ports:
+            - containerPort: 29752
+              name: healthz
+              protocol: TCP
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: smb-vhdx
+          image: gcr.io/k8s-staging-sig-storage/csiplugin:canary
+          imagePullPolicy: IfNotPresent
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --mode=controller
+            - --drivername=smb-vhdx.csi.windows.microsoft.com
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: WINRM_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_HOST
+            - name: WINRM_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PORT
+                  optional: true
+            - name: WINRM_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_TLS
+                  optional: true
+            - name: WINRM_INSECURE
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_INSECURE
+                  optional: true
+            - name: WINRM_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_AUTH
+                  optional: true
+            - name: WINRM_TIMEOUT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_TIMEOUT
+                  optional: true
+            - name: WINRM_PS_IMPORT
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PS_IMPORT
+                  optional: true
+            - name: WINRM_USER
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_USER
+            - name: WINRM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: csi-driver-winrm
+                  key: WINRM_PASSWORD
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+      volumes:
+        - name: socket-dir
+          emptyDir: {}

--- a/deploy/csi-driver-for-windows-storage-server-driverinfo-nodeonly.yaml
+++ b/deploy/csi-driver-for-windows-storage-server-driverinfo-nodeonly.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: iscsi.csi.windows.microsoft.com
+spec:
+  attachRequired: false
+  volumeLifecycleModes:
+    - Persistent
+    - Ephemeral

--- a/deploy/install-driver.sh
+++ b/deploy/install-driver.sh
@@ -20,15 +20,25 @@ ver="master"
 use_local=false
 nfs_kerberos=false
 nfs_kerberos_flavor="krb5"
+node_only=false
 
 usage() {
   cat <<EOF
-Usage: $0 [version] [local] [--nfs-kerberos] [--nfs-kerberos-flavor krb5|krb5i|krb5p]
+Usage: $0 [version] [local] [--node-only] [--nfs-kerberos] [--nfs-kerberos-flavor krb5|krb5i|krb5p]
 
 Examples:
   $0
   $0 v1.0.1
+  $0 master local --node-only
   $0 master local --nfs-kerberos --nfs-kerberos-flavor krb5p
+
+Before installing controllers, either create Secret/kube-system/csi-driver-winrm
+with WINRM_HOST, WINRM_USER, and WINRM_PASSWORD keys, or export those environment
+variables and this script will create/update the Secret for you.
+
+Use --node-only for static, pre-provisioned volumes. This installs the Linux
+node side and CSIDriver objects only, skips WinRM/controller setup, and disables
+CSI attach for iSCSI.
 EOF
 }
 
@@ -36,6 +46,9 @@ while [[ "$#" -gt 0 ]]; do
   case "$1" in
     local|--local)
       use_local=true
+      ;;
+    --node-only|--nodeonly)
+      node_only=true
       ;;
     --nfs-kerberos|--kerberos)
       nfs_kerberos=true
@@ -84,6 +97,33 @@ apply_manifest() {
   kubectl apply -f "$repo/$1"
 }
 
+ensure_winrm_secret() {
+  if kubectl -n kube-system get secret csi-driver-winrm >/dev/null 2>&1; then
+    return
+  fi
+  if [[ -z "${WINRM_HOST:-}" || -z "${WINRM_USER:-}" || -z "${WINRM_PASSWORD:-}" ]]; then
+    echo "missing Secret/kube-system/csi-driver-winrm and WINRM_HOST/WINRM_USER/WINRM_PASSWORD are not all set" >&2
+    echo "create the secret manually or export those variables before running install-driver.sh" >&2
+    exit 1
+  fi
+  secret_args=(
+    --from-literal=WINRM_HOST="$WINRM_HOST"
+    --from-literal=WINRM_PORT="${WINRM_PORT:-5986}"
+    --from-literal=WINRM_TLS="${WINRM_TLS:-true}"
+    --from-literal=WINRM_INSECURE="${WINRM_INSECURE:-true}"
+    --from-literal=WINRM_AUTH="${WINRM_AUTH:-basic}"
+    --from-literal=WINRM_TIMEOUT="${WINRM_TIMEOUT:-60s}"
+    --from-literal=WINRM_USER="$WINRM_USER"
+    --from-literal=WINRM_PASSWORD="$WINRM_PASSWORD"
+  )
+  if [[ -n "${WINRM_PS_IMPORT:-}" ]]; then
+    secret_args+=(--from-literal=WINRM_PS_IMPORT="$WINRM_PS_IMPORT")
+  fi
+  kubectl -n kube-system create secret generic csi-driver-winrm \
+    "${secret_args[@]}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
 enable_nfs_kerberos() {
   echo "Enabling NFS Kerberos environment for NFS node daemonsets..."
   kubectl -n kube-system set env daemonset/csi-nfs-node -c nfs \
@@ -101,7 +141,14 @@ enable_nfs_kerberos() {
 }
 
 echo "Installing Windows storage CSI drivers, version: $ver ..."
-apply_manifest "csi-driver-for-windows-storage-server-driverinfo.yaml"
+if [[ "$node_only" == true ]]; then
+  echo "node-only mode enabled; skipping controller and WinRM setup"
+  apply_manifest "csi-driver-for-windows-storage-server-driverinfo-nodeonly.yaml"
+else
+  ensure_winrm_secret
+  apply_manifest "csi-driver-for-windows-storage-server-controller.yaml"
+  apply_manifest "csi-driver-for-windows-storage-server-driverinfo.yaml"
+fi
 apply_manifest "csi-nfs-for-windows-driverinfo.yaml"
 apply_manifest "csi-nfs-vhdx-for-windows-driverinfo.yaml"
 apply_manifest "csi-smb-for-windows-driverinfo.yaml"

--- a/deploy/install-driver.sh
+++ b/deploy/install-driver.sh
@@ -93,15 +93,47 @@ if [[ "$use_local" == true ]]; then
   repo="./deploy"
 fi
 
+chart_path="chart/csi-driver-for-windows-storage-server/Chart.yaml"
+driver_image_repository="ghcr.io/taliesins/csi-driver-for-windows-storage-server"
+
 apply_manifest() {
   kubectl apply -f "$repo/$1"
 }
 
-ensure_winrm_secret() {
-  if kubectl -n kube-system get secret csi-driver-winrm >/dev/null 2>&1; then
-    return
+chart_app_version() {
+  if [[ "$use_local" == true ]]; then
+    sed -nE 's/^appVersion:[[:space:]]*"?([^"]+)"?[[:space:]]*$/\1/p' "$chart_path" | head -n 1
+  else
+    curl -fsSL "https://raw.githubusercontent.com/taliesins/csi-driver-for-windows-storage-server/$ver/$chart_path" \
+      | sed -nE 's/^appVersion:[[:space:]]*"?([^"]+)"?[[:space:]]*$/\1/p' \
+      | head -n 1
   fi
+}
+
+apply_controller_manifest() {
+  local app_version
+  app_version="$(chart_app_version)"
+  if [[ -z "$app_version" ]]; then
+    echo "could not determine chart appVersion for controller image tag" >&2
+    exit 1
+  fi
+
+  if [[ "$use_local" == true ]]; then
+    sed -E "s#image: ${driver_image_repository}:[^[:space:]]+#image: ${driver_image_repository}:${app_version}#g" \
+      "$repo/csi-driver-for-windows-storage-server-controller.yaml" \
+      | kubectl apply -f -
+  else
+    curl -fsSL "$repo/csi-driver-for-windows-storage-server-controller.yaml" \
+      | sed -E "s#image: ${driver_image_repository}:[^[:space:]]+#image: ${driver_image_repository}:${app_version}#g" \
+      | kubectl apply -f -
+  fi
+}
+
+ensure_winrm_secret() {
   if [[ -z "${WINRM_HOST:-}" || -z "${WINRM_USER:-}" || -z "${WINRM_PASSWORD:-}" ]]; then
+    if kubectl -n kube-system get secret csi-driver-winrm >/dev/null 2>&1; then
+      return
+    fi
     echo "missing Secret/kube-system/csi-driver-winrm and WINRM_HOST/WINRM_USER/WINRM_PASSWORD are not all set" >&2
     echo "create the secret manually or export those variables before running install-driver.sh" >&2
     exit 1
@@ -146,7 +178,7 @@ if [[ "$node_only" == true ]]; then
   apply_manifest "csi-driver-for-windows-storage-server-driverinfo-nodeonly.yaml"
 else
   ensure_winrm_secret
-  apply_manifest "csi-driver-for-windows-storage-server-controller.yaml"
+  apply_controller_manifest
   apply_manifest "csi-driver-for-windows-storage-server-driverinfo.yaml"
 fi
 apply_manifest "csi-nfs-for-windows-driverinfo.yaml"

--- a/deploy/uninstall-driver.sh
+++ b/deploy/uninstall-driver.sh
@@ -21,11 +21,14 @@ use_local=false
 
 usage() {
   cat <<EOF
-Usage: $0 [version] [local] [--nfs-kerberos] [--nfs-kerberos-flavor krb5|krb5i|krb5p]
+Usage: $0 [version] [local] [--node-only] [--nfs-kerberos] [--nfs-kerberos-flavor krb5|krb5i|krb5p]
 
 Kerberos flags are accepted so install and uninstall commands can use the same
 argument set; uninstall deletes the daemonsets and does not need separate
 Kerberos cleanup.
+
+The --node-only flag is accepted for symmetry with install-driver.sh; uninstall
+deletes both regular and node-only CSIDriver manifests when present.
 EOF
 }
 
@@ -33,6 +36,8 @@ while [[ "$#" -gt 0 ]]; do
   case "$1" in
     local|--local)
       use_local=true
+      ;;
+    --node-only|--nodeonly)
       ;;
     --nfs-kerberos|--kerberos)
       ;;
@@ -76,9 +81,11 @@ delete_manifest "csi-smb-for-windows-node.yaml"
 delete_manifest "csi-nfs-vhdx-for-windows-node.yaml"
 delete_manifest "csi-nfs-for-windows-node.yaml"
 delete_manifest "csi-driver-for-windows-storage-server-node.yaml"
+delete_manifest "csi-driver-for-windows-storage-server-controller.yaml"
 delete_manifest "csi-smb-vhdx-for-windows-driverinfo.yaml"
 delete_manifest "csi-smb-for-windows-driverinfo.yaml"
 delete_manifest "csi-nfs-vhdx-for-windows-driverinfo.yaml"
 delete_manifest "csi-nfs-for-windows-driverinfo.yaml"
+delete_manifest "csi-driver-for-windows-storage-server-driverinfo-nodeonly.yaml"
 delete_manifest "csi-driver-for-windows-storage-server-driverinfo.yaml"
 echo 'Windows storage CSI drivers uninstalled successfully.'

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,3 +27,5 @@ name, access mode, credentials, and feature set.
 
 Each protocol folder starts with `01-storageclass/` and then builds on the PVC
 names from the previous examples.
+Each protocol folder also includes static PV examples for both `nodeOnly=false`
+and `nodeOnly=true` installs.

--- a/examples/iscsi/01-storageclass/README.md
+++ b/examples/iscsi/01-storageclass/README.md
@@ -14,9 +14,19 @@ Windows-generated `TargetIqn`, and passes that IQN to the node for login. Set
 resolves the path on the Windows server from `CSI_VHDX_PARENT_PATH`; if that is
 not set, it falls back to `%SystemDrive%\iSCSIVirtualDisks`.
 
-`csi.storage.k8s.io/node-stage-secret-name` and
-`csi.storage.k8s.io/node-stage-secret-namespace` are optional for iSCSI. Set
-them only when the Windows iSCSI target requires CHAP.
+CHAP is optional for iSCSI. To have the driver configure both sides, set the
+same Secret for `csi.storage.k8s.io/provisioner-secret-name`,
+`csi.storage.k8s.io/controller-publish-secret-name`, and
+`csi.storage.k8s.io/node-stage-secret-name`. The controller uses the
+provisioner/controller-publish secret to configure Windows target CHAP and
+reverse CHAP. The node uses the node-stage secret for the Linux open-iscsi
+login.
+
+Windows target CHAP uses `node.session.auth.username`,
+`node.session.auth.password`, and optionally `node.session.auth.username_in` /
+`node.session.auth.password_in` for reverse CHAP. Discovery CHAP keys configure
+Linux open-iscsi discovery only; Windows Server iSCSI target CHAP is configured
+per target.
 
 ## Apply
 

--- a/examples/iscsi/01-storageclass/README.md
+++ b/examples/iscsi/01-storageclass/README.md
@@ -17,10 +17,14 @@ not set, it falls back to `%SystemDrive%\iSCSIVirtualDisks`.
 CHAP is optional for iSCSI. To have the driver configure both sides, set the
 same Secret for `csi.storage.k8s.io/provisioner-secret-name`,
 `csi.storage.k8s.io/controller-publish-secret-name`, and
-`csi.storage.k8s.io/node-stage-secret-name`. The controller uses the
-provisioner/controller-publish secret to configure Windows target CHAP and
-reverse CHAP. The node uses the node-stage secret for the Linux open-iscsi
-login.
+`csi.storage.k8s.io/node-stage-secret-name`. For each of those name keys, also
+set the matching namespace key:
+`csi.storage.k8s.io/provisioner-secret-namespace`,
+`csi.storage.k8s.io/controller-publish-secret-namespace`, and
+`csi.storage.k8s.io/node-stage-secret-namespace`. Both the name and namespace
+must be configured for the provisioner, controller-publish, and node-stage
+secrets so the driver can resolve secrets for Windows CHAP/reverse CHAP and
+Linux open-iscsi login.
 
 Windows target CHAP uses `node.session.auth.username`,
 `node.session.auth.password`, and optionally `node.session.auth.username_in` /

--- a/examples/iscsi/01-storageclass/storageclass.yaml
+++ b/examples/iscsi/01-storageclass/storageclass.yaml
@@ -20,8 +20,14 @@ parameters:
   # Optional: filesystem type defaults to ext4.
   # csi.storage.k8s.io/fstype: "xfs"
 
-  # Optional CHAP credentials. Leave unset unless the Windows iSCSI target
-  # requires CHAP for node login.
+  # Optional CHAP credentials. Leave unset unless you want the controller to
+  # configure Windows target CHAP and the node to log in with CHAP. Use the
+  # same Secret for provisioning, controller publish, and node stage so both
+  # sides see matching credentials.
+  # csi.storage.k8s.io/provisioner-secret-name: "iscsi-chap"
+  # csi.storage.k8s.io/provisioner-secret-namespace: "${pvc.namespace}"
+  # csi.storage.k8s.io/controller-publish-secret-name: "iscsi-chap"
+  # csi.storage.k8s.io/controller-publish-secret-namespace: "${pvc.namespace}"
   # csi.storage.k8s.io/node-stage-secret-name: "iscsi-chap"
   # csi.storage.k8s.io/node-stage-secret-namespace: "${pvc.namespace}"
   # iface: "default"

--- a/examples/iscsi/02-filesystem-pvc-pod/README.md
+++ b/examples/iscsi/02-filesystem-pvc-pod/README.md
@@ -1,6 +1,6 @@
 # iSCSI Filesystem PVC and Pod
 
-Creates a 200Gi RWO PVC and runs Postgres mounting it.
+Creates a 1Gi RWO PVC and runs Postgres mounting it.
 
 ## Apply
 
@@ -11,5 +11,7 @@ kubectl -n apps apply -f pod.yaml
 kubectl -n apps get pvc,pod
 ```
 
-Apply `secret-chap.yaml` first only if the StorageClass enables
-`csi.storage.k8s.io/node-stage-secret-name` for CHAP.
+Apply `secret-chap.yaml` first only if the StorageClass enables CHAP secret
+parameters. Use the same Secret for provisioning, controller publish, and node
+stage so the controller can configure Windows target CHAP and the node can log
+in with matching Linux open-iscsi credentials.

--- a/examples/iscsi/02-filesystem-pvc-pod/pvc.yaml
+++ b/examples/iscsi/02-filesystem-pvc-pod/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: iscsi-for-windows-rwo
   resources:
     requests:
-      storage: 200Gi
+      storage: 1Gi

--- a/examples/iscsi/02-filesystem-pvc-pod/secret-chap.yaml
+++ b/examples/iscsi/02-filesystem-pvc-pod/secret-chap.yaml
@@ -13,5 +13,7 @@ stringData:
   # node.session.auth.password_in: "TargetS3cret!"
 
   # Discovery CHAP, optional:
+  # These configure Linux open-iscsi discovery only. Windows Server target CHAP
+  # is configured per target from the node.session.* keys above.
   # discovery.sendtargets.auth.username: "discuser"
   # discovery.sendtargets.auth.password: "DiscS3cret!"

--- a/examples/iscsi/04-restore-from-snapshot/pvc-restore.yaml
+++ b/examples/iscsi/04-restore-from-snapshot/pvc-restore.yaml
@@ -13,4 +13,4 @@ spec:
     apiGroup: snapshot.storage.k8s.io
   resources:
     requests:
-      storage: 200Gi
+      storage: 1Gi

--- a/examples/iscsi/05-expand-online/README.md
+++ b/examples/iscsi/05-expand-online/README.md
@@ -1,6 +1,6 @@
 # iSCSI Online Volume Expansion
 
-Increase `PVC/apps/db-data` from 200Gi to 300Gi. The controller grows the VHDX;
+Increase `PVC/apps/db-data` from 1Gi to 2Gi. The controller grows the VHDX;
 the node rescans iSCSI and grows the filesystem online.
 
 ## Patch
@@ -8,7 +8,7 @@ the node rescans iSCSI and grows the filesystem online.
 ```bash
 kubectl -n apps patch pvc db-data \
   --type merge \
-  -p '{"spec":{"resources":{"requests":{"storage":"300Gi"}}}}'
+  -p '{"spec":{"resources":{"requests":{"storage":"2Gi"}}}}'
 ```
 
 Watch events and capacity:

--- a/examples/iscsi/06-raw-block/README.md
+++ b/examples/iscsi/06-raw-block/README.md
@@ -1,6 +1,6 @@
 # iSCSI Raw Block Volume
 
-Requests a 50Gi RWO raw block volume and exposes it at `/dev/walraw`.
+Requests a 1Gi RWO raw block volume and exposes it at `/dev/walraw`.
 
 ## Apply
 

--- a/examples/iscsi/06-raw-block/pvc-block.yaml
+++ b/examples/iscsi/06-raw-block/pvc-block.yaml
@@ -10,4 +10,4 @@ spec:
   volumeMode: Block
   resources:
     requests:
-      storage: 50Gi
+      storage: 1Gi

--- a/examples/iscsi/07-static-pv-import/README.md
+++ b/examples/iscsi/07-static-pv-import/README.md
@@ -6,8 +6,16 @@ backing path. If the Windows target name is different from the target IQN, add
 the `targetName` query parameter so controller publish/unpublish can update the
 right Windows target object.
 
-The sample uses the URI volume ID form supported by the driver. Replace the
-values before applying.
+The default sample uses the URI volume ID form supported by the driver. The
+alternate `pv-volumeattributes.yaml` sample keeps the `volumeHandle` simple and
+puts `targetPortal`, `targetIQN`, `lun`, and `iface` in `volumeAttributes`.
+Replace the values before applying.
+
+For pod moves between Kubernetes nodes, the Windows target must allow the node
+initiator IQN for the node where the pod lands. With the controller installed,
+the driver updates that target access during attach. If you use these static PVs
+without the controller, preconfigure the target with every Linux node initiator
+IQN that may run the pod.
 
 ## Apply
 
@@ -16,4 +24,13 @@ kubectl apply -f pv.yaml
 kubectl -n apps apply -f pvc.yaml
 kubectl get pv preprovisioned-iscsi
 kubectl -n apps get pvc preprovisioned-iscsi-claim
+```
+
+## Alternate volumeAttributes form
+
+```bash
+kubectl apply -f pv-volumeattributes.yaml
+kubectl -n apps apply -f pvc-volumeattributes.yaml
+kubectl get pv preprovisioned-iscsi-attributes
+kubectl -n apps get pvc preprovisioned-iscsi-attributes-claim
 ```

--- a/examples/iscsi/07-static-pv-import/pv.yaml
+++ b/examples/iscsi/07-static-pv-import/pv.yaml
@@ -4,13 +4,13 @@ metadata:
   name: preprovisioned-iscsi
 spec:
   capacity:
-    storage: 100Gi
+    storage: 1Gi
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   storageClassName: iscsi-for-windows-rwo
   csi:
     driver: iscsi.csi.windows.microsoft.com
-    volumeHandle: "iscsi://win-storage.lab.local:3260/iqn.1991-05.com.microsoft:win-storage-preprovisioned-iscsi/lun/0?name=preprovisioned-iscsi&targetName=preprovisioned-iscsi&vhdxPath=E%3A%5CiSCSIVirtualDisks%5Cpreprovisioned-iscsi.vhdx&capacityBytes=107374182400"
+    volumeHandle: "iscsi://win-storage.lab.local:3260/iqn.1991-05.com.microsoft:win-storage-preprovisioned-iscsi/lun/0?name=preprovisioned-iscsi&targetName=preprovisioned-iscsi&vhdxPath=E%3A%5CiSCSIVirtualDisks%5Cpreprovisioned-iscsi.vhdx&capacityBytes=1073741824"
     fsType: xfs
     volumeAttributes: {}

--- a/examples/iscsi/07-static-pv-import/pvc.yaml
+++ b/examples/iscsi/07-static-pv-import/pvc.yaml
@@ -9,5 +9,5 @@ spec:
   storageClassName: iscsi-for-windows-rwo
   resources:
     requests:
-      storage: 100Gi
+      storage: 1Gi
   volumeName: preprovisioned-iscsi

--- a/examples/iscsi/08-static-nodeonly-true/README.md
+++ b/examples/iscsi/08-static-nodeonly-true/README.md
@@ -6,7 +6,7 @@ skipped, so the driver will not create VHDX files, create targets, map LUNs,
 configure CHAP, or update Windows target initiator access.
 
 ```bash
-kubectl create ns apps
+kubectl create namespace apps --dry-run=client -o yaml | kubectl apply -f -
 kubectl apply -f pv.yaml
 kubectl -n apps apply -f pvc.yaml
 kubectl -n apps apply -f pod.yaml

--- a/examples/iscsi/08-static-nodeonly-true/README.md
+++ b/examples/iscsi/08-static-nodeonly-true/README.md
@@ -1,0 +1,16 @@
+# iSCSI Static PV with nodeOnly=true
+
+Use this example when Windows iSCSI storage is already configured and you only
+want the Linux CSI node side installed. The controller and WinRM backend are
+skipped, so the driver will not create VHDX files, create targets, map LUNs,
+configure CHAP, or update Windows target initiator access.
+
+```bash
+kubectl create ns apps
+kubectl apply -f pv.yaml
+kubectl -n apps apply -f pvc.yaml
+kubectl -n apps apply -f pod.yaml
+```
+
+For pod moves between nodes, preconfigure the Windows target to allow every
+Linux node initiator IQN that may run the pod.

--- a/examples/iscsi/08-static-nodeonly-true/pod.yaml
+++ b/examples/iscsi/08-static-nodeonly-true/pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: static-nodeonly-iscsi-pod
+  namespace: apps
+spec:
+  restartPolicy: Always
+  containers:
+    - name: app
+      image: registry.k8s.io/busybox
+      command: ["/bin/sh", "-c", "while true; do date >> /data/heartbeat.log; sleep 30; done"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: static-nodeonly-iscsi-claim

--- a/examples/iscsi/08-static-nodeonly-true/pv.yaml
+++ b/examples/iscsi/08-static-nodeonly-true/pv.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: static-nodeonly-iscsi
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  csi:
+    driver: iscsi.csi.windows.microsoft.com
+    volumeHandle: "static-nodeonly-iscsi"
+    fsType: xfs
+    volumeAttributes:
+      targetPortal: "win-storage.lab.local:3260"
+      targetIQN: "iqn.1991-05.com.microsoft:win-storage-static-nodeonly-iscsi"
+      lun: "0"
+      iface: "default"

--- a/examples/iscsi/08-static-nodeonly-true/pvc.yaml
+++ b/examples/iscsi/08-static-nodeonly-true/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: static-nodeonly-iscsi-claim
+  namespace: apps
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 1Gi
+  volumeName: static-nodeonly-iscsi

--- a/examples/iscsi/README.md
+++ b/examples/iscsi/README.md
@@ -12,6 +12,7 @@ These examples use `iscsi.csi.windows.microsoft.com` and
 5. `05-expand-online`
 6. `06-raw-block`
 7. `07-static-pv-import`
+8. `08-static-nodeonly-true`
 
 iSCSI supports RWO filesystem volumes, raw block volumes, optional CHAP secrets,
 snapshots, restore, expansion, and static imports.

--- a/examples/nfs-vhdx/02-rwx-pvc-pods/pvc.yaml
+++ b/examples/nfs-vhdx/02-rwx-pvc-pods/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: nfs-vhdx-for-windows-rwx
   resources:
     requests:
-      storage: 100Gi
+      storage: 1Gi

--- a/examples/nfs-vhdx/04-restore-from-snapshot/pvc-restore.yaml
+++ b/examples/nfs-vhdx/04-restore-from-snapshot/pvc-restore.yaml
@@ -13,4 +13,4 @@ spec:
     apiGroup: snapshot.storage.k8s.io
   resources:
     requests:
-      storage: 100Gi
+      storage: 1Gi

--- a/examples/nfs-vhdx/05-expand-online/README.md
+++ b/examples/nfs-vhdx/05-expand-online/README.md
@@ -1,6 +1,6 @@
 # NFS VHDX Online Volume Expansion
 
-Increase `PVC/apps/shared-nfs-vhdx-data` from 100Gi to 150Gi. The controller
+Increase `PVC/apps/shared-nfs-vhdx-data` from 1Gi to 2Gi. The controller
 expands the backing VHDX and the mounted filesystem on the Windows storage
 server. Node expansion is not required for NFS.
 
@@ -9,7 +9,7 @@ server. Node expansion is not required for NFS.
 ```bash
 kubectl -n apps patch pvc shared-nfs-vhdx-data \
   --type merge \
-  -p '{"spec":{"resources":{"requests":{"storage":"150Gi"}}}}'
+  -p '{"spec":{"resources":{"requests":{"storage":"2Gi"}}}}'
 ```
 
 Watch events and capacity:

--- a/examples/nfs-vhdx/06-static-pv-import/pv.yaml
+++ b/examples/nfs-vhdx/06-static-pv-import/pv.yaml
@@ -4,12 +4,12 @@ metadata:
   name: preprovisioned-nfs-vhdx
 spec:
   capacity:
-    storage: 100Gi
+    storage: 1Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   storageClassName: nfs-vhdx-for-windows-rwx
   csi:
     driver: nfs-vhdx.csi.windows.microsoft.com
-    volumeHandle: "nfs://win-storage.lab.local/preprovisioned-nfs-vhdx?name=preprovisioned-nfs-vhdx&shareBackend=vhdx&sharePath=E%3A%5CNfsVhdxShares%5Cpreprovisioned-nfs-vhdx&vhdxPath=E%3A%5CNfsShareVhdx%5Cpreprovisioned-nfs-vhdx.vhdx&capacityBytes=107374182400"
+    volumeHandle: "nfs://win-storage.lab.local/preprovisioned-nfs-vhdx?name=preprovisioned-nfs-vhdx&shareBackend=vhdx&sharePath=E%3A%5CNfsVhdxShares%5Cpreprovisioned-nfs-vhdx&vhdxPath=E%3A%5CNfsShareVhdx%5Cpreprovisioned-nfs-vhdx.vhdx&capacityBytes=1073741824"
     volumeAttributes: {}

--- a/examples/nfs-vhdx/06-static-pv-import/pvc.yaml
+++ b/examples/nfs-vhdx/06-static-pv-import/pvc.yaml
@@ -10,4 +10,4 @@ spec:
   volumeName: preprovisioned-nfs-vhdx
   resources:
     requests:
-      storage: 100Gi
+      storage: 1Gi

--- a/examples/nfs-vhdx/07-static-nodeonly-true/README.md
+++ b/examples/nfs-vhdx/07-static-nodeonly-true/README.md
@@ -1,0 +1,14 @@
+# NFS VHDX Static PV with nodeOnly=true
+
+Use this example when the Windows NFS export already exists, the VHDX is already
+mounted/exported on the Windows storage server, and you only want the Linux CSI
+node side installed.
+
+```bash
+kubectl create ns apps
+kubectl apply -f pv.yaml
+kubectl -n apps apply -f pvc.yaml
+kubectl -n apps apply -f pod.yaml
+```
+
+Replace the server name and export path before applying.

--- a/examples/nfs-vhdx/07-static-nodeonly-true/pod.yaml
+++ b/examples/nfs-vhdx/07-static-nodeonly-true/pod.yaml
@@ -9,6 +9,14 @@ spec:
     - name: app
       image: registry.k8s.io/busybox
       command: ["/bin/sh", "-c", "while true; do date >> /data/heartbeat.log; sleep 30; done"]
+      securityContext:
+        privileged: false
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        runAsNonRoot: true
+        runAsUser: 1000
       volumeMounts:
         - name: data
           mountPath: /data

--- a/examples/nfs-vhdx/07-static-nodeonly-true/pod.yaml
+++ b/examples/nfs-vhdx/07-static-nodeonly-true/pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: static-nodeonly-nfs-vhdx-pod
+  namespace: apps
+spec:
+  restartPolicy: Always
+  containers:
+    - name: app
+      image: registry.k8s.io/busybox
+      command: ["/bin/sh", "-c", "while true; do date >> /data/heartbeat.log; sleep 30; done"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: static-nodeonly-nfs-vhdx-claim

--- a/examples/nfs-vhdx/07-static-nodeonly-true/pv.yaml
+++ b/examples/nfs-vhdx/07-static-nodeonly-true/pv.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: static-nodeonly-nfs-vhdx
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  csi:
+    driver: nfs-vhdx.csi.windows.microsoft.com
+    volumeHandle: "static-nodeonly-nfs-vhdx"
+    volumeAttributes:
+      protocol: "nfs"
+      nfsServer: "win-storage.lab.local"
+      nfsExportPath: "/static-nodeonly-nfs-vhdx"
+      nfsVersion: "4.1"

--- a/examples/nfs-vhdx/07-static-nodeonly-true/pvc.yaml
+++ b/examples/nfs-vhdx/07-static-nodeonly-true/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: static-nodeonly-nfs-vhdx-claim
+  namespace: apps
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 1Gi
+  volumeName: static-nodeonly-nfs-vhdx

--- a/examples/nfs-vhdx/README.md
+++ b/examples/nfs-vhdx/README.md
@@ -13,6 +13,7 @@ NFS.
 4. `04-restore-from-snapshot`
 5. `05-expand-online`
 6. `06-static-pv-import`
+7. `07-static-nodeonly-true`
 
 NFS VHDX supports RWX filesystem volumes, snapshots, restore, expansion, and
 static imports. Use `../nfs` when you want a normal directory-backed share

--- a/examples/nfs/02-rwx-pvc-pods/README.md
+++ b/examples/nfs/02-rwx-pvc-pods/README.md
@@ -1,6 +1,6 @@
 # NFS RWX PVC and Pods
 
-Creates a 100Gi ReadWriteMany PVC and mounts it from two pods.
+Creates a 1Gi ReadWriteMany PVC and mounts it from two pods.
 
 ## Apply
 

--- a/examples/nfs/02-rwx-pvc-pods/pvc.yaml
+++ b/examples/nfs/02-rwx-pvc-pods/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: nfs-for-windows-rwx
   resources:
     requests:
-      storage: 100Gi
+      storage: 1Gi

--- a/examples/nfs/05-expand-online/README.md
+++ b/examples/nfs/05-expand-online/README.md
@@ -1,6 +1,6 @@
 # NFS Online Volume Expansion
 
-Increase `PVC/apps/shared-nfs-data` from 100Gi to 150Gi. The controller expands
+Increase `PVC/apps/shared-nfs-data` from 1Gi to 2Gi. The controller expands
 the backing file-share storage. Node expansion is not required for NFS.
 
 ## Patch
@@ -8,7 +8,7 @@ the backing file-share storage. Node expansion is not required for NFS.
 ```bash
 kubectl -n apps patch pvc shared-nfs-data \
   --type merge \
-  -p '{"spec":{"resources":{"requests":{"storage":"150Gi"}}}}'
+  -p '{"spec":{"resources":{"requests":{"storage":"2Gi"}}}}'
 ```
 
 Watch events and capacity:

--- a/examples/nfs/06-static-pv-import/pv.yaml
+++ b/examples/nfs/06-static-pv-import/pv.yaml
@@ -4,12 +4,12 @@ metadata:
   name: preprovisioned-nfs
 spec:
   capacity:
-    storage: 100Gi
+    storage: 1Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   storageClassName: nfs-for-windows-rwx
   csi:
     driver: nfs.csi.windows.microsoft.com
-    volumeHandle: "nfs://win-storage.lab.local/preprovisioned-nfs?name=preprovisioned-nfs&shareBackend=directory&sharePath=E%3A%5CNfsShares%5Cpreprovisioned-nfs&vhdxPath=E%3A%5CNfsShares%5Cpreprovisioned-nfs&capacityBytes=107374182400"
+    volumeHandle: "nfs://win-storage.lab.local/preprovisioned-nfs?name=preprovisioned-nfs&shareBackend=directory&sharePath=E%3A%5CNfsShares%5Cpreprovisioned-nfs&vhdxPath=E%3A%5CNfsShares%5Cpreprovisioned-nfs&capacityBytes=1073741824"
     volumeAttributes: {}

--- a/examples/nfs/06-static-pv-import/pvc.yaml
+++ b/examples/nfs/06-static-pv-import/pvc.yaml
@@ -9,5 +9,5 @@ spec:
   storageClassName: nfs-for-windows-rwx
   resources:
     requests:
-      storage: 100Gi
+      storage: 1Gi
   volumeName: preprovisioned-nfs

--- a/examples/nfs/07-static-nodeonly-true/README.md
+++ b/examples/nfs/07-static-nodeonly-true/README.md
@@ -1,0 +1,13 @@
+# NFS Static PV with nodeOnly=true
+
+Use this example when the Windows NFS export already exists and you only want
+the Linux CSI node side installed.
+
+```bash
+kubectl create ns apps
+kubectl apply -f pv.yaml
+kubectl -n apps apply -f pvc.yaml
+kubectl -n apps apply -f pod.yaml
+```
+
+Replace the server name and export path before applying.

--- a/examples/nfs/07-static-nodeonly-true/pod.yaml
+++ b/examples/nfs/07-static-nodeonly-true/pod.yaml
@@ -5,10 +5,21 @@ metadata:
   namespace: apps
 spec:
   restartPolicy: Always
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
   containers:
     - name: app
       image: registry.k8s.io/busybox
       command: ["/bin/sh", "-c", "while true; do date >> /data/heartbeat.log; sleep 30; done"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        runAsNonRoot: true
+        runAsUser: 1000
       volumeMounts:
         - name: data
           mountPath: /data

--- a/examples/nfs/07-static-nodeonly-true/pod.yaml
+++ b/examples/nfs/07-static-nodeonly-true/pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: static-nodeonly-nfs-pod
+  namespace: apps
+spec:
+  restartPolicy: Always
+  containers:
+    - name: app
+      image: registry.k8s.io/busybox
+      command: ["/bin/sh", "-c", "while true; do date >> /data/heartbeat.log; sleep 30; done"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: static-nodeonly-nfs-claim

--- a/examples/nfs/07-static-nodeonly-true/pv.yaml
+++ b/examples/nfs/07-static-nodeonly-true/pv.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: static-nodeonly-nfs
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  csi:
+    driver: nfs.csi.windows.microsoft.com
+    volumeHandle: "static-nodeonly-nfs"
+    volumeAttributes:
+      protocol: "nfs"
+      nfsServer: "win-storage.lab.local"
+      nfsExportPath: "/static-nodeonly-nfs"
+      nfsVersion: "4.1"

--- a/examples/nfs/07-static-nodeonly-true/pvc.yaml
+++ b/examples/nfs/07-static-nodeonly-true/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: static-nodeonly-nfs-claim
+  namespace: apps
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 1Gi
+  volumeName: static-nodeonly-nfs

--- a/examples/nfs/README.md
+++ b/examples/nfs/README.md
@@ -11,6 +11,7 @@ point at an existing NFS export path.
 2. `02-rwx-pvc-pods`
 3. `05-expand-online`
 4. `06-static-pv-import`
+5. `07-static-nodeonly-true`
 
 Directory-backed NFS supports RWX filesystem volumes, expansion, and static
 imports. Snapshots and restore are provided by the VHDX-backed NFS driver in

--- a/examples/smb-vhdx/02-rwx-pvc-pods/pvc.yaml
+++ b/examples/smb-vhdx/02-rwx-pvc-pods/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: smb-vhdx-for-windows-rwx
   resources:
     requests:
-      storage: 100Gi
+      storage: 1Gi

--- a/examples/smb-vhdx/04-restore-from-snapshot/pvc-restore.yaml
+++ b/examples/smb-vhdx/04-restore-from-snapshot/pvc-restore.yaml
@@ -13,4 +13,4 @@ spec:
     apiGroup: snapshot.storage.k8s.io
   resources:
     requests:
-      storage: 100Gi
+      storage: 1Gi

--- a/examples/smb-vhdx/05-expand-online/README.md
+++ b/examples/smb-vhdx/05-expand-online/README.md
@@ -1,6 +1,6 @@
 # SMB VHDX Online Volume Expansion
 
-Increase `PVC/apps/shared-smb-vhdx-data` from 100Gi to 150Gi. The controller
+Increase `PVC/apps/shared-smb-vhdx-data` from 1Gi to 2Gi. The controller
 expands the backing VHDX and the mounted filesystem on the Windows storage
 server. Node expansion is not required for SMB.
 
@@ -9,7 +9,7 @@ server. Node expansion is not required for SMB.
 ```bash
 kubectl -n apps patch pvc shared-smb-vhdx-data \
   --type merge \
-  -p '{"spec":{"resources":{"requests":{"storage":"150Gi"}}}}'
+  -p '{"spec":{"resources":{"requests":{"storage":"2Gi"}}}}'
 ```
 
 Watch events and capacity:

--- a/examples/smb-vhdx/06-static-pv-import/pv.yaml
+++ b/examples/smb-vhdx/06-static-pv-import/pv.yaml
@@ -4,12 +4,12 @@ metadata:
   name: preprovisioned-smb-vhdx
 spec:
   capacity:
-    storage: 100Gi
+    storage: 1Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   storageClassName: smb-vhdx-for-windows-rwx
   csi:
     driver: smb-vhdx.csi.windows.microsoft.com
-    volumeHandle: "smb://win-storage.lab.local/preprovisioned-smb-vhdx?name=preprovisioned-smb-vhdx&shareBackend=vhdx&sharePath=E%3A%5CSmbVhdxShares%5Cpreprovisioned-smb-vhdx&vhdxPath=E%3A%5CSmbShareVhdx%5Cpreprovisioned-smb-vhdx.vhdx&capacityBytes=107374182400"
+    volumeHandle: "smb://win-storage.lab.local/preprovisioned-smb-vhdx?name=preprovisioned-smb-vhdx&shareBackend=vhdx&sharePath=E%3A%5CSmbVhdxShares%5Cpreprovisioned-smb-vhdx&vhdxPath=E%3A%5CSmbShareVhdx%5Cpreprovisioned-smb-vhdx.vhdx&capacityBytes=1073741824"
     volumeAttributes: {}

--- a/examples/smb-vhdx/06-static-pv-import/pvc.yaml
+++ b/examples/smb-vhdx/06-static-pv-import/pvc.yaml
@@ -10,4 +10,4 @@ spec:
   volumeName: preprovisioned-smb-vhdx
   resources:
     requests:
-      storage: 100Gi
+      storage: 1Gi

--- a/examples/smb-vhdx/07-static-nodeonly-true/README.md
+++ b/examples/smb-vhdx/07-static-nodeonly-true/README.md
@@ -1,0 +1,15 @@
+# SMB VHDX Static PV with nodeOnly=true
+
+Use this example when the Windows SMB share already exists, the VHDX is already
+mounted/shared on the Windows storage server, and you only want the Linux CSI
+node side installed.
+
+```bash
+kubectl create ns apps
+kubectl -n apps apply -f secret-smb.yaml
+kubectl apply -f pv.yaml
+kubectl -n apps apply -f pvc.yaml
+kubectl -n apps apply -f pod.yaml
+```
+
+Replace the server name, share name, and credentials before applying.

--- a/examples/smb-vhdx/07-static-nodeonly-true/pod.yaml
+++ b/examples/smb-vhdx/07-static-nodeonly-true/pod.yaml
@@ -5,10 +5,22 @@ metadata:
   namespace: apps
 spec:
   restartPolicy: Always
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
   containers:
     - name: app
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.36.1
       command: ["/bin/sh", "-c", "while true; do date >> /data/heartbeat.log; sleep 30; done"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
       volumeMounts:
         - name: data
           mountPath: /data

--- a/examples/smb-vhdx/07-static-nodeonly-true/pod.yaml
+++ b/examples/smb-vhdx/07-static-nodeonly-true/pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: static-nodeonly-smb-vhdx-pod
+  namespace: apps
+spec:
+  restartPolicy: Always
+  containers:
+    - name: app
+      image: registry.k8s.io/busybox
+      command: ["/bin/sh", "-c", "while true; do date >> /data/heartbeat.log; sleep 30; done"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: static-nodeonly-smb-vhdx-claim

--- a/examples/smb-vhdx/07-static-nodeonly-true/pv.yaml
+++ b/examples/smb-vhdx/07-static-nodeonly-true/pv.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: static-nodeonly-smb-vhdx
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  csi:
+    driver: smb-vhdx.csi.windows.microsoft.com
+    volumeHandle: "static-nodeonly-smb-vhdx"
+    nodeStageSecretRef:
+      name: static-smb-vhdx-credentials
+      namespace: apps
+    volumeAttributes:
+      protocol: "smb"
+      smbServer: "win-storage.lab.local"
+      smbShareName: "static-nodeonly-smb-vhdx"
+      smbVersion: "3.1.1"

--- a/examples/smb-vhdx/07-static-nodeonly-true/pvc.yaml
+++ b/examples/smb-vhdx/07-static-nodeonly-true/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: static-nodeonly-smb-vhdx-claim
+  namespace: apps
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 1Gi
+  volumeName: static-nodeonly-smb-vhdx

--- a/examples/smb-vhdx/07-static-nodeonly-true/secret-smb.yaml
+++ b/examples/smb-vhdx/07-static-nodeonly-true/secret-smb.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: static-smb-vhdx-credentials
+  namespace: apps
+type: Opaque
+stringData:
+  smbUsername: "storage-user"
+  smbPassword: "S3cret!"
+  smbDomain: "EXAMPLE"

--- a/examples/smb-vhdx/07-static-nodeonly-true/secret-smb.yaml
+++ b/examples/smb-vhdx/07-static-nodeonly-true/secret-smb.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: apps
 type: Opaque
 stringData:
-  smbUsername: "storage-user"
-  smbPassword: "S3cret!"
-  smbDomain: "EXAMPLE"
+  smbUsername: "REPLACE_WITH_USERNAME"
+  smbPassword: "REPLACE_WITH_PASSWORD"
+  smbDomain: "REPLACE_WITH_DOMAIN"

--- a/examples/smb-vhdx/README.md
+++ b/examples/smb-vhdx/README.md
@@ -13,6 +13,7 @@ SMB.
 4. `04-restore-from-snapshot`
 5. `05-expand-online`
 6. `06-static-pv-import`
+7. `07-static-nodeonly-true`
 
 SMB VHDX supports RWX filesystem volumes, node-stage mount credentials,
 snapshots, restore, expansion, and static imports. Use `../smb` when you want a

--- a/examples/smb/02-rwx-pvc-pods/README.md
+++ b/examples/smb/02-rwx-pvc-pods/README.md
@@ -1,6 +1,6 @@
 # SMB RWX PVC and Pods
 
-Creates a 100Gi ReadWriteMany PVC and mounts it from two pods.
+Creates a 1Gi ReadWriteMany PVC and mounts it from two pods.
 
 ## Apply
 

--- a/examples/smb/02-rwx-pvc-pods/pvc.yaml
+++ b/examples/smb/02-rwx-pvc-pods/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: smb-for-windows-rwx
   resources:
     requests:
-      storage: 100Gi
+      storage: 1Gi

--- a/examples/smb/05-expand-online/README.md
+++ b/examples/smb/05-expand-online/README.md
@@ -1,6 +1,6 @@
 # SMB Online Volume Expansion
 
-Increase `PVC/apps/shared-smb-data` from 100Gi to 150Gi. The controller expands
+Increase `PVC/apps/shared-smb-data` from 1Gi to 2Gi. The controller expands
 the backing file-share storage. Node expansion is not required for SMB.
 
 ## Patch
@@ -8,7 +8,7 @@ the backing file-share storage. Node expansion is not required for SMB.
 ```bash
 kubectl -n apps patch pvc shared-smb-data \
   --type merge \
-  -p '{"spec":{"resources":{"requests":{"storage":"150Gi"}}}}'
+  -p '{"spec":{"resources":{"requests":{"storage":"2Gi"}}}}'
 ```
 
 Watch events and capacity:

--- a/examples/smb/06-static-pv-import/pv.yaml
+++ b/examples/smb/06-static-pv-import/pv.yaml
@@ -4,12 +4,12 @@ metadata:
   name: preprovisioned-smb
 spec:
   capacity:
-    storage: 100Gi
+    storage: 1Gi
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   storageClassName: smb-for-windows-rwx
   csi:
     driver: smb.csi.windows.microsoft.com
-    volumeHandle: "smb://win-storage.lab.local/preprovisioned-smb?name=preprovisioned-smb&shareBackend=directory&sharePath=E%3A%5CSmbShares%5Cpreprovisioned-smb&vhdxPath=E%3A%5CSmbShares%5Cpreprovisioned-smb&capacityBytes=107374182400"
+    volumeHandle: "smb://win-storage.lab.local/preprovisioned-smb?name=preprovisioned-smb&shareBackend=directory&sharePath=E%3A%5CSmbShares%5Cpreprovisioned-smb&vhdxPath=E%3A%5CSmbShares%5Cpreprovisioned-smb&capacityBytes=1073741824"
     volumeAttributes: {}

--- a/examples/smb/06-static-pv-import/pvc.yaml
+++ b/examples/smb/06-static-pv-import/pvc.yaml
@@ -9,5 +9,5 @@ spec:
   storageClassName: smb-for-windows-rwx
   resources:
     requests:
-      storage: 100Gi
+      storage: 1Gi
   volumeName: preprovisioned-smb

--- a/examples/smb/07-static-nodeonly-true/README.md
+++ b/examples/smb/07-static-nodeonly-true/README.md
@@ -1,0 +1,14 @@
+# SMB Static PV with nodeOnly=true
+
+Use this example when the Windows SMB share already exists and you only want the
+Linux CSI node side installed.
+
+```bash
+kubectl create ns apps
+kubectl -n apps apply -f secret-smb.yaml
+kubectl apply -f pv.yaml
+kubectl -n apps apply -f pvc.yaml
+kubectl -n apps apply -f pod.yaml
+```
+
+Replace the server name, share name, and credentials before applying.

--- a/examples/smb/07-static-nodeonly-true/pod.yaml
+++ b/examples/smb/07-static-nodeonly-true/pod.yaml
@@ -5,10 +5,24 @@ metadata:
   namespace: apps
 spec:
   restartPolicy: Always
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: app
       image: registry.k8s.io/busybox
       command: ["/bin/sh", "-c", "while true; do date >> /data/heartbeat.log; sleep 30; done"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
       volumeMounts:
         - name: data
           mountPath: /data

--- a/examples/smb/07-static-nodeonly-true/pod.yaml
+++ b/examples/smb/07-static-nodeonly-true/pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: static-nodeonly-smb-pod
+  namespace: apps
+spec:
+  restartPolicy: Always
+  containers:
+    - name: app
+      image: registry.k8s.io/busybox
+      command: ["/bin/sh", "-c", "while true; do date >> /data/heartbeat.log; sleep 30; done"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: static-nodeonly-smb-claim

--- a/examples/smb/07-static-nodeonly-true/pod.yaml
+++ b/examples/smb/07-static-nodeonly-true/pod.yaml
@@ -13,7 +13,7 @@ spec:
       type: RuntimeDefault
   containers:
     - name: app
-      image: registry.k8s.io/busybox
+      image: registry.k8s.io/busybox:1.36.1
       command: ["/bin/sh", "-c", "while true; do date >> /data/heartbeat.log; sleep 30; done"]
       securityContext:
         allowPrivilegeEscalation: false

--- a/examples/smb/07-static-nodeonly-true/pv.yaml
+++ b/examples/smb/07-static-nodeonly-true/pv.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: static-nodeonly-smb
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  csi:
+    driver: smb.csi.windows.microsoft.com
+    volumeHandle: "static-nodeonly-smb"
+    nodeStageSecretRef:
+      name: static-smb-credentials
+      namespace: apps
+    volumeAttributes:
+      protocol: "smb"
+      smbServer: "win-storage.lab.local"
+      smbShareName: "static-nodeonly-smb"
+      smbVersion: "3.1.1"

--- a/examples/smb/07-static-nodeonly-true/pvc.yaml
+++ b/examples/smb/07-static-nodeonly-true/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: static-nodeonly-smb-claim
+  namespace: apps
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 1Gi
+  volumeName: static-nodeonly-smb

--- a/examples/smb/07-static-nodeonly-true/secret-smb.yaml
+++ b/examples/smb/07-static-nodeonly-true/secret-smb.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: static-smb-credentials
+  namespace: apps
+type: Opaque
+stringData:
+  smbUsername: "storage-user"
+  smbPassword: "S3cret!"
+  smbDomain: "EXAMPLE"

--- a/examples/smb/07-static-nodeonly-true/secret-smb.yaml
+++ b/examples/smb/07-static-nodeonly-true/secret-smb.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: apps
 type: Opaque
 stringData:
-  smbUsername: "storage-user"
-  smbPassword: "S3cret!"
-  smbDomain: "EXAMPLE"
+  smbUsername: "REPLACE_WITH_USERNAME"
+  smbPassword: "REPLACE_WITH_PASSWORD"
+  smbDomain: "REPLACE_WITH_DOMAIN"

--- a/examples/smb/README.md
+++ b/examples/smb/README.md
@@ -11,6 +11,7 @@ point at an existing SMB share path.
 2. `02-rwx-pvc-pods`
 3. `05-expand-online`
 4. `06-static-pv-import`
+5. `07-static-nodeonly-true`
 
 Directory-backed SMB supports RWX filesystem volumes, node-stage mount
 credentials, expansion, and static imports. Snapshots and restore are provided

--- a/pkg/iscsi/backend_winrm.go
+++ b/pkg/iscsi/backend_winrm.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -124,6 +126,60 @@ func NewWinRMBackend(host string, port int, https, insecure bool, user, pass str
 		PSModuleImport: "Import-Module IscsiTarget",
 		Timeout:        timeout,
 	}
+}
+
+func (b *WinRMBackend) Validate(ctx context.Context) error {
+	return b.ValidateConnection(ctx)
+}
+
+func (b *WinRMBackend) ValidateConnection(ctx context.Context) error {
+	if b == nil {
+		return fmt.Errorf("WinRM backend is nil")
+	}
+	if b.Endpoint == nil {
+		return fmt.Errorf("WinRM endpoint is nil")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		timeout := b.Timeout
+		if timeout <= 0 {
+			timeout = 60 * time.Second
+		}
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	var out struct {
+		OK           bool   `json:"ok"`
+		ComputerName string `json:"computerName"`
+		UserName     string `json:"userName"`
+	}
+	err := b.runPS(ctx, `@{ ok=$true; computerName=[string]$env:COMPUTERNAME; userName=[string][Security.Principal.WindowsIdentity]::GetCurrent().Name }`, &out)
+	if err != nil {
+		return fmt.Errorf("WinRM connection validation failed for %s: %w", b.endpointURL(), err)
+	}
+	if !out.OK {
+		return fmt.Errorf("WinRM connection validation failed for %s: remote probe returned ok=false", b.endpointURL())
+	}
+	return nil
+}
+
+func (b *WinRMBackend) endpointURL() string {
+	if b == nil || b.Endpoint == nil {
+		return "<nil>"
+	}
+	scheme := "http"
+	if b.Endpoint.HTTPS {
+		scheme = "https"
+	}
+	host := strings.TrimSpace(b.Endpoint.Host)
+	if host == "" {
+		host = "<empty-host>"
+	}
+	return fmt.Sprintf("%s://%s/wsman", scheme, net.JoinHostPort(host, strconv.Itoa(b.Endpoint.Port)))
 }
 
 func (b *WinRMBackend) clientParameters() (*winrm.Parameters, error) {

--- a/pkg/iscsi/backend_winrm.go
+++ b/pkg/iscsi/backend_winrm.go
@@ -248,6 +248,34 @@ if (-not [string]::IsNullOrWhiteSpace($targetIQN) -and [string]$t.TargetIqn -ne 
 	return out.TargetIQN, nil
 }
 
+func (b *WinRMBackend) ConfigureTargetChap(ctx context.Context, targetName string, opts TargetChapOptions) error {
+	targetName = strings.TrimSpace(targetName)
+	if targetName == "" {
+		return fmt.Errorf("target name is required")
+	}
+	if !opts.Enabled() {
+		return nil
+	}
+	s := fmt.Sprintf(`
+$targetName = '%s'
+$params = @{ ComputerName=$IscsiTargetComputerName; TargetName=$targetName }
+if (-not [string]::IsNullOrWhiteSpace('%s')) {
+  $chapSecret = ConvertTo-SecureString -String '%s' -AsPlainText -Force
+  $params.EnableChap = $true
+  $params.Chap = [pscredential]::new('%s', $chapSecret)
+}
+if (-not [string]::IsNullOrWhiteSpace('%s')) {
+  $reverseChapSecret = ConvertTo-SecureString -String '%s' -AsPlainText -Force
+  $params.EnableReverseChap = $true
+  $params.ReverseChap = [pscredential]::new('%s', $reverseChapSecret)
+}
+Set-IscsiServerTarget @params | Out-Null
+@{ ok = $true }
+`, escapePS(targetName), escapePS(opts.ChapUser), escapePS(opts.ChapSecret), escapePS(opts.ChapUser), escapePS(opts.ReverseChapUser), escapePS(opts.ReverseChapSecret), escapePS(opts.ReverseChapUser))
+	var out map[string]any
+	return b.runPS(ctx, s, &out)
+}
+
 func (b *WinRMBackend) CreateVirtualDisk(ctx context.Context, name, parentDir string, sizeBytes int64) (string, int64, error) {
 	s := fmt.Sprintf(`
 $parentDir = Resolve-CsiVHDXParentPath '%s'

--- a/pkg/iscsi/backend_winrm_test.go
+++ b/pkg/iscsi/backend_winrm_test.go
@@ -2,6 +2,7 @@ package iscsi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -69,6 +70,44 @@ func TestWinRMBackend_ClientParametersAuth(t *testing.T) {
 			require.NotNil(t, params)
 		})
 	}
+}
+
+func TestWinRMBackend_ValidateConnection(t *testing.T) {
+	t.Run("runs startup probe", func(t *testing.T) {
+		backend := NewWinRMBackend("storage.example.test", 5986, true, true, "admin", "pass", 10*time.Second)
+		called := false
+		backend.psRunner = func(ctx context.Context, script string, out any) error {
+			called = true
+			_, hasDeadline := ctx.Deadline()
+			assert.True(t, hasDeadline)
+			assert.Contains(t, script, "WindowsIdentity")
+			return json.Unmarshal([]byte(`{"ok":true,"computerName":"STORAGE01","userName":"STORAGE01\\admin"}`), out)
+		}
+
+		require.NoError(t, backend.ValidateConnection(context.Background()))
+		assert.True(t, called)
+	})
+
+	t.Run("wraps probe failure with endpoint", func(t *testing.T) {
+		backend := NewWinRMBackend("beast3-pc", 5986, true, true, "admin", "pass", 10*time.Second)
+		backend.psRunner = func(ctx context.Context, script string, out any) error {
+			return errors.New(`Post "https://beast3-pc:5986/wsman": dial tcp: lookup beast3-pc: no such host`)
+		}
+
+		err := backend.ValidateConnection(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "WinRM connection validation failed")
+		assert.Contains(t, err.Error(), "https://beast3-pc:5986/wsman")
+		assert.Contains(t, err.Error(), "no such host")
+	})
+
+	t.Run("rejects missing endpoint", func(t *testing.T) {
+		backend := &WinRMBackend{}
+
+		err := backend.ValidateConnection(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "WinRM endpoint is nil")
+	})
 }
 
 type fakeWinRMClient struct {

--- a/pkg/iscsi/backend_winrm_test.go
+++ b/pkg/iscsi/backend_winrm_test.go
@@ -317,6 +317,8 @@ func TestWinRMBackend_ConfigureTargetChap(t *testing.T) {
 	backend := newUnitWinRMBackend()
 	backend.psRunner = func(ctx context.Context, script string, out any) error {
 		assert.Contains(t, script, "Set-IscsiServerTarget @params")
+		assert.Contains(t, script, "$targetName = 'target-001'")
+		assert.Contains(t, script, "TargetName=$targetName")
 		assert.Contains(t, script, "$params.EnableChap = $true")
 		assert.Contains(t, script, "$params.Chap = [pscredential]::new('dbnode01', $chapSecret)")
 		assert.Contains(t, script, "$params.EnableReverseChap = $true")

--- a/pkg/iscsi/backend_winrm_test.go
+++ b/pkg/iscsi/backend_winrm_test.go
@@ -313,6 +313,41 @@ func TestWinRMBackend_EnsureTarget(t *testing.T) {
 	}
 }
 
+func TestWinRMBackend_ConfigureTargetChap(t *testing.T) {
+	backend := newUnitWinRMBackend()
+	backend.psRunner = func(ctx context.Context, script string, out any) error {
+		assert.Contains(t, script, "Set-IscsiServerTarget @params")
+		assert.Contains(t, script, "$params.EnableChap = $true")
+		assert.Contains(t, script, "$params.Chap = [pscredential]::new('dbnode01', $chapSecret)")
+		assert.Contains(t, script, "$params.EnableReverseChap = $true")
+		assert.Contains(t, script, "$params.ReverseChap = [pscredential]::new('targetid', $reverseChapSecret)")
+		assert.Contains(t, script, "S3cret!")
+		assert.Contains(t, script, "TargetS3cret!")
+		if out != nil {
+			copyTestOutput(out, map[string]any{"ok": true})
+		}
+		return nil
+	}
+
+	err := backend.ConfigureTargetChap(context.Background(), "target-001", TargetChapOptions{
+		ChapUser:          "dbnode01",
+		ChapSecret:        "S3cret!",
+		ReverseChapUser:   "targetid",
+		ReverseChapSecret: "TargetS3cret!",
+	})
+	require.NoError(t, err)
+}
+
+func TestWinRMBackend_ConfigureTargetChapNoopWhenEmpty(t *testing.T) {
+	backend := newUnitWinRMBackend()
+	backend.psRunner = func(ctx context.Context, script string, out any) error {
+		t.Fatalf("ConfigureTargetChap should not run PowerShell when options are empty")
+		return nil
+	}
+
+	require.NoError(t, backend.ConfigureTargetChap(context.Background(), "target-001", TargetChapOptions{}))
+}
+
 // ---------------------------------------------------------------------------
 // CreateVirtualDisk tests
 // ---------------------------------------------------------------------------

--- a/pkg/iscsi/controllerserver.go
+++ b/pkg/iscsi/controllerserver.go
@@ -749,9 +749,6 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		if targetIQN == "" {
 			return nil, status.Errorf(codes.Internal, "EnsureTarget returned an empty target IQN for target %q", existingTargetName)
 		}
-		if err := cs.configureTargetChapFromSecrets(ctx, existingTargetName, req.GetSecrets()); err != nil {
-			return nil, err
-		}
 		if existingLUN < 0 {
 			lun, err := cs.Driver.backend.MapDiskToTarget(ctx, existingTargetName, vhdxPath)
 			if err != nil {

--- a/pkg/iscsi/controllerserver.go
+++ b/pkg/iscsi/controllerserver.go
@@ -36,6 +36,7 @@ Assumptions / contracts:
 
 - cs.Driver.backend provides the following methods (see your WinRM backend):
   EnsureTarget(ctx, targetName, targetIQN) (actualTargetIQN string, err error)
+  ConfigureTargetChap(ctx, targetName string, opts TargetChapOptions) error
   CreateVirtualDisk(ctx, name, parentDir string, sizeBytes int64) (vhdxPath string, actualSize int64, err error)
   MapDiskToTarget(ctx, targetName, vhdxPath string) (lun int32, err error)
   UnmapDiskFromTarget(ctx, targetName, vhdxPath string) error
@@ -529,6 +530,54 @@ func targetPortalAddress(targetPortal string, portalPort int) string {
 	return net.JoinHostPort(targetPortal, strconv.Itoa(portalPort))
 }
 
+func withIscsiVolumeContextParams(ctx map[string]string, params map[string]string) map[string]string {
+	if iface, ok := getStringParam(params, "iface"); ok {
+		ctx["iface"] = iface
+	}
+	return ctx
+}
+
+func targetChapOptionsFromSecrets(secrets map[string]string) (TargetChapOptions, error) {
+	chapUser := strings.TrimSpace(secrets["node.session.auth.username"])
+	chapSecret := strings.TrimSpace(secrets["node.session.auth.password"])
+	reverseChapUser := strings.TrimSpace(secrets["node.session.auth.username_in"])
+	reverseChapSecret := strings.TrimSpace(secrets["node.session.auth.password_in"])
+
+	opts := TargetChapOptions{}
+	if chapUser != "" || chapSecret != "" {
+		if chapUser == "" || chapSecret == "" {
+			return TargetChapOptions{}, status.Error(codes.InvalidArgument, "node.session.auth.username and node.session.auth.password must both be set for Windows target CHAP")
+		}
+		opts.ChapUser = chapUser
+		opts.ChapSecret = chapSecret
+	}
+	if reverseChapUser != "" || reverseChapSecret != "" {
+		if reverseChapUser == "" || reverseChapSecret == "" {
+			return TargetChapOptions{}, status.Error(codes.InvalidArgument, "node.session.auth.username_in and node.session.auth.password_in must both be set for Windows target reverse CHAP")
+		}
+		if opts.ChapUser == "" {
+			return TargetChapOptions{}, status.Error(codes.InvalidArgument, "reverse CHAP requires node.session.auth.username and node.session.auth.password")
+		}
+		opts.ReverseChapUser = reverseChapUser
+		opts.ReverseChapSecret = reverseChapSecret
+	}
+	return opts, nil
+}
+
+func (cs *ControllerServer) configureTargetChapFromSecrets(ctx context.Context, targetName string, secrets map[string]string) error {
+	opts, err := targetChapOptionsFromSecrets(secrets)
+	if err != nil {
+		return err
+	}
+	if !opts.Enabled() {
+		return nil
+	}
+	if err := cs.Driver.backend.ConfigureTargetChap(ctx, targetName, opts); err != nil {
+		return status.Errorf(codes.Internal, "ConfigureTargetChap: %v", err)
+	}
+	return nil
+}
+
 func volumeContextForVolumeID(v *VolumeID) map[string]string {
 	switch v.Protocol {
 	case ProtocolNFS:
@@ -649,6 +698,9 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		if targetIQN == "" {
 			return nil, status.Errorf(codes.Internal, "EnsureTarget returned an empty target IQN for target %q", targetName)
 		}
+		if err := cs.configureTargetChapFromSecrets(ctx, targetName, req.GetSecrets()); err != nil {
+			return nil, err
+		}
 		lun, err := cs.Driver.backend.MapDiskToTarget(ctx, targetName, exportedPath)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "MapDiskToTarget(exported): %v", err)
@@ -667,12 +719,12 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			Volume: &csi.Volume{
 				VolumeId:      vid,
 				CapacityBytes: vi.SizeBytes,
-				VolumeContext: map[string]string{
+				VolumeContext: withIscsiVolumeContextParams(map[string]string{
 					"targetPortal": targetPortalWithPort,
 					"iqn":          targetIQN,
 					"lun":          strconv.Itoa(int(lun)),
 					"source":       "snapshot",
-				},
+				}, params),
 				ContentSource: req.GetVolumeContentSource(),
 			},
 		}, nil
@@ -697,6 +749,9 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		if targetIQN == "" {
 			return nil, status.Errorf(codes.Internal, "EnsureTarget returned an empty target IQN for target %q", existingTargetName)
 		}
+		if err := cs.configureTargetChapFromSecrets(ctx, existingTargetName, req.GetSecrets()); err != nil {
+			return nil, err
+		}
 		if existingLUN < 0 {
 			lun, err := cs.Driver.backend.MapDiskToTarget(ctx, existingTargetName, vhdxPath)
 			if err != nil {
@@ -717,11 +772,11 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 			Volume: &csi.Volume{
 				VolumeId:      vid,
 				CapacityBytes: existingSize,
-				VolumeContext: map[string]string{
+				VolumeContext: withIscsiVolumeContextParams(map[string]string{
 					"targetPortal": targetPortalWithPort,
 					"iqn":          targetIQN,
 					"lun":          strconv.Itoa(int(existingLUN)),
-				},
+				}, params),
 			},
 		}, nil
 	}
@@ -737,6 +792,9 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	}
 	if targetIQN == "" {
 		return nil, status.Errorf(codes.Internal, "EnsureTarget returned an empty target IQN for target %q", targetName)
+	}
+	if err := cs.configureTargetChapFromSecrets(ctx, targetName, req.GetSecrets()); err != nil {
+		return nil, err
 	}
 	lun, err := cs.Driver.backend.MapDiskToTarget(ctx, targetName, vhdxPath)
 	if err != nil {
@@ -756,11 +814,11 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		Volume: &csi.Volume{
 			VolumeId:      vid,
 			CapacityBytes: actual,
-			VolumeContext: map[string]string{
+			VolumeContext: withIscsiVolumeContextParams(map[string]string{
 				"targetPortal": targetPortalWithPort,
 				"iqn":          targetIQN,
 				"lun":          strconv.Itoa(int(lun)),
-			},
+			}, params),
 		},
 	}, nil
 }
@@ -1130,6 +1188,9 @@ func (cs *ControllerServer) ControllerPublishVolume(ctx context.Context, req *cs
 	targetName := targetNameFromVolID(id)
 	if targetName == "" || id.TargetIQN == "" {
 		return nil, status.Error(codes.InvalidArgument, "volume_id is missing target name or target IQN")
+	}
+	if err := cs.configureTargetChapFromSecrets(ctx, targetName, req.GetSecrets()); err != nil {
+		return nil, err
 	}
 	if err := cs.Driver.backend.AllowInitiator(ctx, targetName, initiatorIQN); err != nil {
 		return nil, status.Errorf(codes.Internal, "AllowInitiator: %v", err)

--- a/pkg/iscsi/controllerserver_test.go
+++ b/pkg/iscsi/controllerserver_test.go
@@ -16,6 +16,7 @@ import (
 
 type mockBackend struct {
 	ensureTargetFn              func(ctx context.Context, targetName, targetIQN string) (string, error)
+	configureTargetChapFn       func(ctx context.Context, targetName string, opts TargetChapOptions) error
 	createVirtualDiskFn         func(ctx context.Context, name, parentDir string, sizeBytes int64) (string, int64, error)
 	mapDiskToTargetFn           func(ctx context.Context, targetName, vhdxPath string) (int32, error)
 	unmapDiskFromTargetFn       func(ctx context.Context, targetName, vhdxPath string) error
@@ -50,6 +51,12 @@ func (m *mockBackend) EnsureTarget(ctx context.Context, targetName, targetIQN st
 		return m.ensureTargetFn(ctx, targetName, targetIQN)
 	}
 	return firstNonEmpty(targetIQN, targetName), nil
+}
+func (m *mockBackend) ConfigureTargetChap(ctx context.Context, targetName string, opts TargetChapOptions) error {
+	if m.configureTargetChapFn != nil {
+		return m.configureTargetChapFn(ctx, targetName, opts)
+	}
+	return nil
 }
 func (m *mockBackend) CreateVirtualDisk(ctx context.Context, name, parentDir string, sizeBytes int64) (string, int64, error) {
 	if m.createVirtualDiskFn != nil {
@@ -456,6 +463,65 @@ func TestCreateVolume_TargetPortalRequired(t *testing.T) {
 	assert.Contains(t, err.Error(), "targetPortal is required")
 }
 
+func TestTargetChapOptionsFromSecrets(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		opts, err := targetChapOptionsFromSecrets(nil)
+		require.NoError(t, err)
+		assert.False(t, opts.Enabled())
+	})
+
+	t.Run("session chap", func(t *testing.T) {
+		opts, err := targetChapOptionsFromSecrets(map[string]string{
+			"node.session.auth.username": " dbnode01 ",
+			"node.session.auth.password": " S3cret! ",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, TargetChapOptions{ChapUser: "dbnode01", ChapSecret: "S3cret!"}, opts)
+	})
+
+	t.Run("mutual chap", func(t *testing.T) {
+		opts, err := targetChapOptionsFromSecrets(map[string]string{
+			"node.session.auth.username":    "dbnode01",
+			"node.session.auth.password":    "S3cret!",
+			"node.session.auth.username_in": "targetid",
+			"node.session.auth.password_in": "TargetS3cret!",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, TargetChapOptions{
+			ChapUser:          "dbnode01",
+			ChapSecret:        "S3cret!",
+			ReverseChapUser:   "targetid",
+			ReverseChapSecret: "TargetS3cret!",
+		}, opts)
+	})
+
+	t.Run("discovery chap is linux only", func(t *testing.T) {
+		opts, err := targetChapOptionsFromSecrets(map[string]string{
+			"discovery.sendtargets.auth.username": "discuser",
+			"discovery.sendtargets.auth.password": "DiscS3cret!",
+		})
+		require.NoError(t, err)
+		assert.False(t, opts.Enabled())
+	})
+
+	t.Run("missing password", func(t *testing.T) {
+		_, err := targetChapOptionsFromSecrets(map[string]string{
+			"node.session.auth.username": "dbnode01",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "node.session.auth.password")
+	})
+
+	t.Run("reverse requires session chap", func(t *testing.T) {
+		_, err := targetChapOptionsFromSecrets(map[string]string{
+			"node.session.auth.username_in": "targetid",
+			"node.session.auth.password_in": "TargetS3cret!",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reverse CHAP requires")
+	})
+}
+
 func TestCreateVolume_VhdxParentPathOptionalUsesBackendDefault(t *testing.T) {
 	cs, _, mockBackend := newTestControllerServer(t)
 
@@ -483,12 +549,14 @@ func TestCreateVolume_VhdxParentPathOptionalUsesBackendDefault(t *testing.T) {
 		Parameters: map[string]string{
 			"targetPortal": "10.0.0.1:3260",
 			"iqnPrefix":    "iqn.2024-01.com.example",
+			"iface":        "storage0",
 		},
 	})
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, "iqn.2024-01.com.example:test-volume", resp.Volume.VolumeContext["iqn"])
+	assert.Equal(t, "storage0", resp.Volume.VolumeContext["iface"])
 }
 
 func TestCreateVolume_IqnPrefixOptionalUsesWindowsGeneratedIQN(t *testing.T) {
@@ -528,6 +596,53 @@ func TestCreateVolume_IqnPrefixOptionalUsesWindowsGeneratedIQN(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "test-volume", decoded.TargetName)
 	assert.Equal(t, "iqn.1991-05.com.microsoft:win-storage-test-volume", decoded.TargetIQN)
+}
+
+func TestCreateVolume_ConfiguresWindowsTargetChap(t *testing.T) {
+	cs, _, mockBackend := newTestControllerServer(t)
+	var gotTargetName string
+	var gotChap TargetChapOptions
+
+	mockBackend.createVirtualDiskFn = func(ctx context.Context, name, parentDir string, sizeBytes int64) (string, int64, error) {
+		return "D:\\vhdx\\" + name + ".vhdx", sizeBytes, nil
+	}
+	mockBackend.ensureTargetFn = func(ctx context.Context, targetName, targetIQN string) (string, error) {
+		return "iqn.1991-05.com.microsoft:win-storage-test-volume", nil
+	}
+	mockBackend.configureTargetChapFn = func(ctx context.Context, targetName string, opts TargetChapOptions) error {
+		gotTargetName = targetName
+		gotChap = opts
+		return nil
+	}
+	mockBackend.mapDiskToTargetFn = func(ctx context.Context, targetName, vhdxPath string) (int32, error) {
+		return 0, nil
+	}
+
+	resp, err := cs.CreateVolume(context.Background(), &csi.CreateVolumeRequest{
+		Name: "test-volume",
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER}},
+		},
+		Parameters: map[string]string{
+			"targetPortal": "10.0.0.1",
+		},
+		Secrets: map[string]string{
+			"node.session.auth.username":    "dbnode01",
+			"node.session.auth.password":    "S3cret!",
+			"node.session.auth.username_in": "targetid",
+			"node.session.auth.password_in": "TargetS3cret!",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "test-volume", gotTargetName)
+	assert.Equal(t, TargetChapOptions{
+		ChapUser:          "dbnode01",
+		ChapSecret:        "S3cret!",
+		ReverseChapUser:   "targetid",
+		ReverseChapSecret: "TargetS3cret!",
+	}, gotChap)
 }
 
 func TestCreateVolume_InvalidAccessMode(t *testing.T) {
@@ -1304,6 +1419,39 @@ func TestControllerPublishVolume_Success(t *testing.T) {
 	assert.Equal(t, "10.0.0.1:3260", resp.PublishContext["targetPortal"])
 	assert.Equal(t, "iqn.2024-01.com.example:test-volume", resp.PublishContext["iqn"])
 	assert.Equal(t, "0", resp.PublishContext["lun"])
+}
+
+func TestControllerPublishVolume_ConfiguresWindowsTargetChap(t *testing.T) {
+	cs, _, mockBackend := newTestControllerServer(t)
+	var gotTargetName string
+	var gotChap TargetChapOptions
+
+	mockBackend.configureTargetChapFn = func(ctx context.Context, targetName string, opts TargetChapOptions) error {
+		gotTargetName = targetName
+		gotChap = opts
+		return nil
+	}
+	mockBackend.allowInitiatorFn = func(ctx context.Context, targetName, initiatorIQN string) error {
+		assert.Equal(t, "iqn.2024-01.com.example:test-volume", targetName)
+		return nil
+	}
+
+	resp, err := cs.ControllerPublishVolume(context.Background(), &csi.ControllerPublishVolumeRequest{
+		VolumeId: newTestVolumeID(t),
+		NodeId:   "iqn.2024-01.com.example:node-001",
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+		},
+		Secrets: map[string]string{
+			"node.session.auth.username": "dbnode01",
+			"node.session.auth.password": "S3cret!",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "iqn.2024-01.com.example:test-volume", gotTargetName)
+	assert.Equal(t, TargetChapOptions{ChapUser: "dbnode01", ChapSecret: "S3cret!"}, gotChap)
 }
 
 func TestControllerPublishVolume_UsesTargetNameWhenPresent(t *testing.T) {

--- a/pkg/iscsi/controllerserver_test.go
+++ b/pkg/iscsi/controllerserver_test.go
@@ -602,6 +602,7 @@ func TestCreateVolume_ConfiguresWindowsTargetChap(t *testing.T) {
 	cs, _, mockBackend := newTestControllerServer(t)
 	var gotTargetName string
 	var gotChap TargetChapOptions
+	var configureTargetChapCalls int
 
 	mockBackend.createVirtualDiskFn = func(ctx context.Context, name, parentDir string, sizeBytes int64) (string, int64, error) {
 		return "D:\\vhdx\\" + name + ".vhdx", sizeBytes, nil
@@ -610,6 +611,7 @@ func TestCreateVolume_ConfiguresWindowsTargetChap(t *testing.T) {
 		return "iqn.1991-05.com.microsoft:win-storage-test-volume", nil
 	}
 	mockBackend.configureTargetChapFn = func(ctx context.Context, targetName string, opts TargetChapOptions) error {
+		configureTargetChapCalls++
 		gotTargetName = targetName
 		gotChap = opts
 		return nil
@@ -636,6 +638,7 @@ func TestCreateVolume_ConfiguresWindowsTargetChap(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
+	assert.Equal(t, 1, configureTargetChapCalls)
 	assert.Equal(t, "test-volume", gotTargetName)
 	assert.Equal(t, TargetChapOptions{
 		ChapUser:          "dbnode01",
@@ -1433,8 +1436,10 @@ func TestControllerPublishVolume_ConfiguresWindowsTargetChap(t *testing.T) {
 	cs, _, mockBackend := newTestControllerServer(t)
 	var gotTargetName string
 	var gotChap TargetChapOptions
+	var configureTargetChapCalls int
 
 	mockBackend.configureTargetChapFn = func(ctx context.Context, targetName string, opts TargetChapOptions) error {
+		configureTargetChapCalls++
 		gotTargetName = targetName
 		gotChap = opts
 		return nil
@@ -1458,6 +1463,7 @@ func TestControllerPublishVolume_ConfiguresWindowsTargetChap(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
+	assert.Equal(t, 1, configureTargetChapCalls)
 	assert.Equal(t, "iqn.2024-01.com.example:test-volume", gotTargetName)
 	assert.Equal(t, TargetChapOptions{ChapUser: "dbnode01", ChapSecret: "S3cret!"}, gotChap)
 }

--- a/pkg/iscsi/controllerserver_test.go
+++ b/pkg/iscsi/controllerserver_test.go
@@ -734,6 +734,10 @@ func TestCreateVolume_Idempotent_ExistingVolume(t *testing.T) {
 	mockBackend.ensureTargetFn = func(ctx context.Context, targetName, targetIQN string) (string, error) {
 		return firstNonEmpty(targetIQN, targetName), nil
 	}
+	mockBackend.configureTargetChapFn = func(ctx context.Context, targetName string, opts TargetChapOptions) error {
+		t.Fatalf("ConfigureTargetChap should not run for an idempotent existing volume")
+		return nil
+	}
 
 	resp, err := cs.CreateVolume(context.Background(), &csi.CreateVolumeRequest{
 		Name: "test-volume",
@@ -744,6 +748,10 @@ func TestCreateVolume_Idempotent_ExistingVolume(t *testing.T) {
 			"targetPortal":   "10.0.0.1:3260",
 			"vhdxParentPath": "D:\\vhdx",
 			"iqnPrefix":      "iqn.2024-01.com.example",
+		},
+		Secrets: map[string]string{
+			"node.session.auth.username": "dbnode01",
+			"node.session.auth.password": "S3cret!",
 		},
 	})
 

--- a/pkg/iscsi/driver.go
+++ b/pkg/iscsi/driver.go
@@ -24,6 +24,7 @@ import (
 var (
 	newBackendFromEnvForRun        = newWinRMBackendFromEnv
 	newNonBlockingGRPCServerForRun = NewNonBlockingGRPCServer
+	validateBackendForRun          = validateBackendStartup
 )
 
 const driverRunDirEnv = "CSI_DRIVER_RUN_DIR"
@@ -61,6 +62,10 @@ type Backend interface {
 	RestoreSnapshotAsFileShare(ctx context.Context, snapshotID, destinationPath string) error
 	MountFileShareVirtualDisk(ctx context.Context, vhdxPath, mountPath string) error
 	UnmountFileShareVirtualDisk(ctx context.Context, vhdxPath, mountPath string) error
+}
+
+type startupBackendValidator interface {
+	Validate(ctx context.Context) error
 }
 
 type TargetChapOptions struct {
@@ -325,6 +330,10 @@ func (d *driver) serveController(ctx context.Context) {
 	if err != nil {
 		klog.Fatalf("failed to init WinRM backend: %v", err)
 	}
+	klog.Infof("validating WinRM backend configuration")
+	if err := validateBackendForRun(ctx, b); err != nil {
+		klog.Fatalf("failed to validate WinRM backend: %v", err)
+	}
 	d.backend = b
 
 	s := newNonBlockingGRPCServerForRun()
@@ -352,6 +361,14 @@ func waitForServerContext(ctx context.Context, server NonBlockingGRPCServer) {
 		}()
 	}
 	server.Wait()
+}
+
+func validateBackendStartup(ctx context.Context, b Backend) error {
+	validator, ok := b.(startupBackendValidator)
+	if !ok {
+		return nil
+	}
+	return validator.Validate(ctx)
 }
 
 func (d *driver) ensureRunDirectory() {

--- a/pkg/iscsi/driver.go
+++ b/pkg/iscsi/driver.go
@@ -32,6 +32,7 @@ const driverRunDirEnv = "CSI_DRIVER_RUN_DIR"
 // Implemented by WinRMBackend in backend_winrm.go.
 type Backend interface {
 	EnsureTarget(ctx context.Context, targetName, targetIQN string) (string, error)
+	ConfigureTargetChap(ctx context.Context, targetName string, opts TargetChapOptions) error
 	CreateVirtualDisk(ctx context.Context, name, parentDir string, sizeBytes int64) (string, int64, error)
 	MapDiskToTarget(ctx context.Context, targetName, vhdxPath string) (int32, error)
 	UnmapDiskFromTarget(ctx context.Context, targetName, vhdxPath string) error
@@ -60,6 +61,20 @@ type Backend interface {
 	RestoreSnapshotAsFileShare(ctx context.Context, snapshotID, destinationPath string) error
 	MountFileShareVirtualDisk(ctx context.Context, vhdxPath, mountPath string) error
 	UnmountFileShareVirtualDisk(ctx context.Context, vhdxPath, mountPath string) error
+}
+
+type TargetChapOptions struct {
+	ChapUser          string
+	ChapSecret        string
+	ReverseChapUser   string
+	ReverseChapSecret string
+}
+
+func (o TargetChapOptions) Enabled() bool {
+	return strings.TrimSpace(o.ChapUser) != "" ||
+		strings.TrimSpace(o.ChapSecret) != "" ||
+		strings.TrimSpace(o.ReverseChapUser) != "" ||
+		strings.TrimSpace(o.ReverseChapSecret) != ""
 }
 
 const (

--- a/pkg/iscsi/driver_test.go
+++ b/pkg/iscsi/driver_test.go
@@ -487,8 +487,41 @@ func (f *fakeNonBlockingGRPCServer) Stop() {}
 
 func (f *fakeNonBlockingGRPCServer) ForceStop() {}
 
+type validatingMockBackend struct {
+	mockBackend
+	validateCalls int
+	validateErr   error
+}
+
+func (m *validatingMockBackend) Validate(ctx context.Context) error {
+	m.validateCalls++
+	return m.validateErr
+}
+
+func TestValidateBackendStartup(t *testing.T) {
+	t.Run("skips backend without validator", func(t *testing.T) {
+		require.NoError(t, validateBackendStartup(context.Background(), &mockBackend{}))
+	})
+
+	t.Run("calls validator", func(t *testing.T) {
+		backend := &validatingMockBackend{}
+
+		require.NoError(t, validateBackendStartup(context.Background(), backend))
+		assert.Equal(t, 1, backend.validateCalls)
+	})
+
+	t.Run("returns validator error", func(t *testing.T) {
+		backend := &validatingMockBackend{validateErr: errors.New("probe failed")}
+
+		err := validateBackendStartup(context.Background(), backend)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "probe failed")
+		assert.Equal(t, 1, backend.validateCalls)
+	})
+}
+
 func TestDriverRunWiresBackendAndServers(t *testing.T) {
-	backend := &mockBackend{}
+	backend := &validatingMockBackend{}
 	fakeServer := &fakeNonBlockingGRPCServer{}
 	t.Setenv(driverRunDirEnv, t.TempDir())
 
@@ -509,6 +542,7 @@ func TestDriverRunWiresBackendAndServers(t *testing.T) {
 	d.Run(DriverModeController)
 
 	assert.Same(t, backend, d.backend)
+	assert.Equal(t, 1, backend.validateCalls)
 	assert.Equal(t, DriverModeController, d.mode)
 	assert.Equal(t, "tcp://127.0.0.1:10000", fakeServer.endpoint)
 	assert.True(t, fakeServer.waited)

--- a/pkg/iscsi/mock_backend_test.go
+++ b/pkg/iscsi/mock_backend_test.go
@@ -35,6 +35,12 @@ func (m *MockBackend) EnsureTarget(ctx context.Context, targetName, targetIQN st
 	return args.String(0), args.Error(1)
 }
 
+// ConfigureTargetChap mocks ConfigureTargetChap.
+func (m *MockBackend) ConfigureTargetChap(ctx context.Context, targetName string, opts TargetChapOptions) error {
+	args := m.Called(ctx, targetName, opts)
+	return args.Error(0)
+}
+
 // CreateVirtualDisk mocks CreateVirtualDisk.
 func (m *MockBackend) CreateVirtualDisk(ctx context.Context, name, parentDir string, sizeBytes int64) (string, int64, error) {
 	args := m.Called(ctx, name, parentDir, sizeBytes)

--- a/pkg/iscsi/nodeserver.go
+++ b/pkg/iscsi/nodeserver.go
@@ -73,6 +73,62 @@ func fsTypeFromCapability(vc *csi.VolumeCapability) string {
 	return ""
 }
 
+func mountOptionsFromCapability(vc *csi.VolumeCapability) []string {
+	var opts []string
+	if vc == nil {
+		return opts
+	}
+	mount := vc.GetMount()
+	if mount == nil {
+		return opts
+	}
+	for _, opt := range mount.GetMountFlags() {
+		opt = strings.TrimSpace(opt)
+		if opt != "" {
+			opts = append(opts, opt)
+		}
+	}
+	return opts
+}
+
+func appendMountOptions(opts []string, raw string) []string {
+	for _, opt := range strings.Split(raw, ",") {
+		opt = strings.TrimSpace(opt)
+		if opt != "" {
+			opts = append(opts, opt)
+		}
+	}
+	return opts
+}
+
+func iscsiConnectionFromContexts(volumeID string, contexts ...map[string]string) (portal, iqn string, lun int, err error) {
+	if volumeIDContext := volumeContextFromVolumeID(volumeID, ProtocolISCSI); volumeIDContext != nil {
+		contexts = append(contexts, volumeIDContext)
+	}
+	portal = firstContextValueForKeys([]string{"targetPortal", "portal"}, contexts...)
+	if portal == "" {
+		err = status.Error(codes.InvalidArgument, "targetPortal is required in publishContext, volumeContext, or volumeId")
+		return
+	}
+	iqn = firstContextValueForKeys([]string{"iqn", "targetIQN", "targetIqn"}, contexts...)
+	if iqn == "" {
+		err = status.Error(codes.InvalidArgument, "iqn is required in publishContext, volumeContext, or volumeId")
+		return
+	}
+	lunStr := firstContextValueForKeys([]string{"lun", "LUN"}, contexts...)
+	if lunStr == "" {
+		err = status.Error(codes.InvalidArgument, "lun is required in publishContext, volumeContext, or volumeId")
+		return
+	}
+	li, conv := strconv.Atoi(lunStr)
+	if conv != nil {
+		err = status.Errorf(codes.InvalidArgument, "invalid lun: %q", lunStr)
+		return
+	}
+	lun = li
+	return
+}
+
 func isBlockDevice(p string) (bool, error) {
 	st, err := os.Stat(p)
 	if err != nil {
@@ -148,44 +204,20 @@ func (ns *nodeServer) parseStage(req *csi.NodeStageVolumeRequest) (portal, iqn s
 		return
 	}
 	pc := req.GetPublishContext()
-	if pc == nil {
-		err = status.Error(codes.InvalidArgument, "publishContext is required")
+	vc := req.GetVolumeContext()
+	portal, iqn, lun, err = iscsiConnectionFromContexts(req.GetVolumeId(), pc, vc)
+	if err != nil {
 		return
 	}
-	var ok bool
-	if portal, ok = getStr(pc, "targetPortal"); !ok {
-		err = status.Error(codes.InvalidArgument, "publishContext[targetPortal] missing")
-		return
-	}
-	if iqn, ok = getStr(pc, "iqn"); !ok {
-		err = status.Error(codes.InvalidArgument, "publishContext[iqn] missing")
-		return
-	}
-	lunStr, ok := getStr(pc, "lun")
-	if !ok {
-		err = status.Error(codes.InvalidArgument, "publishContext[lun] missing")
-		return
-	}
-	li, conv := strconv.Atoi(lunStr)
-	if conv != nil {
-		err = status.Errorf(codes.InvalidArgument, "invalid lun: %q", lunStr)
-		return
-	}
-	lun = li
 
 	fsType = fsTypeFromCapability(req.GetVolumeCapability())
-	vc := req.GetVolumeContext()
+	mountOpts = append(mountOpts, mountOptionsFromCapability(req.GetVolumeCapability())...)
 	if vc != nil {
 		if v, ok := getStr(vc, "fsType"); ok && fsType == "" {
 			fsType = v
 		}
 		if v, ok := getStr(vc, "mountOptions"); ok {
-			for _, mo := range strings.Split(v, ",") {
-				mo = strings.TrimSpace(mo)
-				if mo != "" {
-					mountOpts = append(mountOpts, mo)
-				}
-			}
+			mountOpts = appendMountOptions(mountOpts, v)
 		}
 		if v, ok := getStr(vc, "iface"); ok {
 			iface = v
@@ -207,44 +239,20 @@ func (ns *nodeServer) parsePublish(req *csi.NodePublishVolumeRequest) (portal, i
 		return
 	}
 	pc := req.GetPublishContext()
-	if pc == nil {
-		err = status.Error(codes.InvalidArgument, "publishContext is required")
+	vc := req.GetVolumeContext()
+	portal, iqn, lun, err = iscsiConnectionFromContexts(req.GetVolumeId(), pc, vc)
+	if err != nil {
 		return
 	}
-	var ok bool
-	if portal, ok = getStr(pc, "targetPortal"); !ok {
-		err = status.Error(codes.InvalidArgument, "publishContext[targetPortal] missing")
-		return
-	}
-	if iqn, ok = getStr(pc, "iqn"); !ok {
-		err = status.Error(codes.InvalidArgument, "publishContext[iqn] missing")
-		return
-	}
-	lunStr, ok := getStr(pc, "lun")
-	if !ok {
-		err = status.Error(codes.InvalidArgument, "publishContext[lun] missing")
-		return
-	}
-	li, conv := strconv.Atoi(lunStr)
-	if conv != nil {
-		err = status.Errorf(codes.InvalidArgument, "invalid lun: %q", lunStr)
-		return
-	}
-	lun = li
 
 	fsType = fsTypeFromCapability(req.GetVolumeCapability())
-	vc := req.GetVolumeContext()
+	mountOpts = append(mountOpts, mountOptionsFromCapability(req.GetVolumeCapability())...)
 	if vc != nil {
 		if v, ok := getStr(vc, "fsType"); ok && fsType == "" {
 			fsType = v
 		}
 		if v, ok := getStr(vc, "mountOptions"); ok {
-			for _, mo := range strings.Split(v, ",") {
-				mo = strings.TrimSpace(mo)
-				if mo != "" {
-					mountOpts = append(mountOpts, mo)
-				}
-			}
+			mountOpts = appendMountOptions(mountOpts, v)
 		}
 	}
 	if fsType == "" {
@@ -256,28 +264,38 @@ func (ns *nodeServer) parsePublish(req *csi.NodePublishVolumeRequest) (portal, i
 
 func publishProtocol(req interface {
 	GetPublishContext() map[string]string
+	GetVolumeContext() map[string]string
+	GetVolumeId() string
 }) Protocol {
-	pc := req.GetPublishContext()
-	proto := strings.ToLower(strings.TrimSpace(pc["protocol"]))
-	switch Protocol(proto) {
-	case ProtocolNFS:
-		return ProtocolNFS
-	case ProtocolSMB:
-		return ProtocolSMB
-	default:
-		return ProtocolISCSI
+	if proto := protocolFromContext(req.GetPublishContext(), req.GetVolumeContext()); proto != "" {
+		return proto
 	}
+	if proto, err := ParseProtocolFromVolumeID(req.GetVolumeId()); err == nil {
+		switch proto {
+		case ProtocolNFS, ProtocolSMB:
+			return proto
+		}
+	}
+	return ProtocolISCSI
+}
+
+func protocolFromContext(contexts ...map[string]string) Protocol {
+	for _, ctx := range contexts {
+		proto := strings.ToLower(strings.TrimSpace(ctx["protocol"]))
+		switch Protocol(proto) {
+		case ProtocolNFS:
+			return ProtocolNFS
+		case ProtocolSMB:
+			return ProtocolSMB
+		}
+	}
+	return ""
 }
 
 func mountOptionsFromContext(vc map[string]string) []string {
 	var opts []string
 	if v, ok := getStr(vc, "mountOptions"); ok {
-		for _, mo := range strings.Split(v, ",") {
-			mo = strings.TrimSpace(mo)
-			if mo != "" {
-				opts = append(opts, mo)
-			}
-		}
+		opts = appendMountOptions(opts, v)
 	}
 	return opts
 }
@@ -291,13 +309,32 @@ func firstContextValue(key string, contexts ...map[string]string) string {
 	return ""
 }
 
-func nfsMountAuthenticationFromContext(vc, pc map[string]string) (string, error) {
-	if value := firstContextValue("nfsMountAuthentication", vc, pc); value != "" {
+func firstContextValueForKeys(keys []string, contexts ...map[string]string) string {
+	for _, ctx := range contexts {
+		for _, key := range keys {
+			if value, ok := getStr(ctx, key); ok {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func volumeContextFromVolumeID(volumeID string, proto Protocol) map[string]string {
+	decoded, err := DecodeVolumeID(volumeID)
+	if err != nil || decoded.Protocol != proto {
+		return nil
+	}
+	return volumeContextForVolumeID(decoded)
+}
+
+func nfsMountAuthenticationFromContext(contexts ...map[string]string) (string, error) {
+	if value := firstContextValue("nfsMountAuthentication", contexts...); value != "" {
 		return normalizeNfsAuthenticationFlavor(value)
 	}
-	raw := firstContextValue("nfsAuthentication", vc, pc)
+	raw := firstContextValue("nfsAuthentication", contexts...)
 	if raw == "" {
-		raw = firstContextValue("nfsauthentication", vc, pc)
+		raw = firstContextValue("nfsauthentication", contexts...)
 	}
 	auth, err := normalizeNfsAuthentication(raw)
 	if err != nil {
@@ -337,44 +374,34 @@ func (ns *nodeServer) stageFileShareVolume(req *csi.NodeStageVolumeRequest, prot
 		return nil, status.Errorf(codes.InvalidArgument, "%s volumes do not support block mode", proto)
 	}
 	pc := req.GetPublishContext()
+	vc := req.GetVolumeContext()
+	volumeIDContext := volumeContextFromVolumeID(req.GetVolumeId(), proto)
 	var source, fsType string
 	switch proto {
 	case ProtocolNFS:
-		server, ok := getStr(pc, "nfsServer")
-		if !ok {
-			server, ok = getStr(pc, "server")
-		}
-		exportPath, ok2 := getStr(pc, "nfsExportPath")
-		if !ok2 {
-			exportPath, ok2 = getStr(pc, "exportPath")
-		}
-		if !ok || !ok2 {
-			return nil, status.Error(codes.InvalidArgument, "publishContext nfsServer/server and nfsExportPath/exportPath are required")
+		server := firstContextValueForKeys([]string{"nfsServer", "server"}, pc, vc, volumeIDContext)
+		exportPath := firstContextValueForKeys([]string{"nfsExportPath", "exportPath"}, pc, vc, volumeIDContext)
+		if server == "" || exportPath == "" {
+			return nil, status.Error(codes.InvalidArgument, "nfsServer/server and nfsExportPath/exportPath are required in publishContext, volumeContext, or volumeId")
 		}
 		source = server + ":" + exportPath
 		fsType = "nfs"
 	case ProtocolSMB:
-		server, ok := getStr(pc, "smbServer")
-		if !ok {
-			server, ok = getStr(pc, "server")
-		}
-		share, ok2 := getStr(pc, "smbShareName")
-		if !ok2 {
-			share, ok2 = getStr(pc, "share")
-		}
-		if !ok || !ok2 {
-			return nil, status.Error(codes.InvalidArgument, "publishContext smbServer/server and smbShareName/share are required")
+		server := firstContextValueForKeys([]string{"smbServer", "server"}, pc, vc, volumeIDContext)
+		share := firstContextValueForKeys([]string{"smbShareName", "share"}, pc, vc, volumeIDContext)
+		if server == "" || share == "" {
+			return nil, status.Error(codes.InvalidArgument, "smbServer/server and smbShareName/share are required in publishContext, volumeContext, or volumeId")
 		}
 		source = fmt.Sprintf("//%s/%s", server, share)
 		fsType = "cifs"
 	}
-	opts := mountOptionsFromContext(req.GetVolumeContext())
+	opts := append(mountOptionsFromCapability(req.GetVolumeCapability()), mountOptionsFromContext(vc)...)
 	switch proto {
 	case ProtocolNFS:
-		if version, ok := getStr(req.GetVolumeContext(), "nfsVersion"); ok {
+		if version, ok := getStr(vc, "nfsVersion"); ok {
 			opts = appendOptionIfMissing(opts, "vers=", "vers="+version)
 		}
-		authentication, err := nfsMountAuthenticationFromContext(req.GetVolumeContext(), pc)
+		authentication, err := nfsMountAuthenticationFromContext(vc, pc, volumeIDContext)
 		if err != nil {
 			return nil, err
 		}
@@ -382,7 +409,7 @@ func (ns *nodeServer) stageFileShareVolume(req *csi.NodeStageVolumeRequest, prot
 			opts = appendOptionIfMissing(opts, "sec=", "sec="+authentication)
 		}
 	case ProtocolSMB:
-		if version, ok := getStr(req.GetVolumeContext(), "smbVersion"); ok {
+		if version, ok := getStr(vc, "smbVersion"); ok {
 			opts = appendOptionIfMissing(opts, "vers=", "vers="+version)
 		}
 		if username, ok := firstSecretValue(req.GetSecrets(), "smbUsername", "username"); ok {
@@ -394,7 +421,7 @@ func (ns *nodeServer) stageFileShareVolume(req *csi.NodeStageVolumeRequest, prot
 		if domain, ok := firstSecretValue(req.GetSecrets(), "smbDomain", "domain"); ok {
 			opts = appendOptionIfMissing(opts, "domain=", "domain="+domain)
 		}
-		if seal, ok := getStr(req.GetVolumeContext(), "smbSeal"); ok {
+		if seal, ok := getStr(vc, "smbSeal"); ok {
 			if enabled, err := strconv.ParseBool(seal); err == nil && enabled {
 				opts = appendOptionIfMissing(opts, "seal", "seal")
 			}

--- a/pkg/iscsi/nodeserver_test.go
+++ b/pkg/iscsi/nodeserver_test.go
@@ -141,7 +141,7 @@ func TestNodeStageVolume_VolumeCapabilityRequired(t *testing.T) {
 	assert.Contains(t, err.Error(), "volumeCapability missing")
 }
 
-func TestNodeStageVolume_PublishContextRequired(t *testing.T) {
+func TestNodeStageVolume_IscsiConnectionRequired(t *testing.T) {
 	ns, _, _ := newTestNodeServer(t)
 	_, err := ns.NodeStageVolume(context.Background(), &csi.NodeStageVolumeRequest{
 		VolumeId:          "test-vol",
@@ -149,7 +149,7 @@ func TestNodeStageVolume_PublishContextRequired(t *testing.T) {
 		VolumeCapability:  &csi.VolumeCapability{},
 	})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "publishContext is required")
+	assert.Contains(t, err.Error(), "targetPortal is required")
 }
 
 func TestNodeStageVolume_BlockVolume(t *testing.T) {
@@ -226,6 +226,72 @@ func TestNodeStageVolume_BlockVolume(t *testing.T) {
 	assert.Empty(t, mockMount.formatAndMounts)
 }
 
+func TestNodeStageVolume_StaticISCSIUsesVolumeContextWithoutPublishContext(t *testing.T) {
+	ns, _, _ := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+
+	var gotConnector iscsilib.Connector
+	originalConnect := iscsilibConnect
+	iscsilibConnect = func(c *iscsilib.Connector) (string, error) {
+		c.MountTargetDevice = &iscsilib.Device{Name: "sdb", Type: "disk"}
+		gotConnector = *c
+		return c.MountTargetDevice.GetPath(), nil
+	}
+	t.Cleanup(func() { iscsilibConnect = originalConnect })
+
+	resp, err := ns.NodeStageVolume(context.Background(), &csi.NodeStageVolumeRequest{
+		VolumeId:          "static-iscsi-volume",
+		StagingTargetPath: stagingTargetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+			AccessType: &csi.VolumeCapability_Block{Block: &csi.VolumeCapability_BlockVolume{}},
+		},
+		VolumeContext: map[string]string{
+			"targetPortal": "10.0.0.1:3260",
+			"targetIQN":    "iqn.2024-01.com.example:static-volume",
+			"lun":          "3",
+			"iface":        "storage0",
+		},
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, "static-iscsi-volume", gotConnector.VolumeName)
+	assert.Equal(t, "iqn.2024-01.com.example:static-volume", gotConnector.TargetIqn)
+	assert.Equal(t, []string{"10.0.0.1:3260"}, gotConnector.TargetPortals)
+	assert.Equal(t, int32(3), gotConnector.Lun)
+	assert.Equal(t, "storage0", gotConnector.Interface)
+}
+
+func TestNodeStageVolume_StaticISCSIUsesVolumeIDWithoutPublishContext(t *testing.T) {
+	ns, _, _ := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+
+	var gotConnector iscsilib.Connector
+	originalConnect := iscsilibConnect
+	iscsilibConnect = func(c *iscsilib.Connector) (string, error) {
+		c.MountTargetDevice = &iscsilib.Device{Name: "sdb", Type: "disk"}
+		gotConnector = *c
+		return c.MountTargetDevice.GetPath(), nil
+	}
+	t.Cleanup(func() { iscsilibConnect = originalConnect })
+
+	resp, err := ns.NodeStageVolume(context.Background(), &csi.NodeStageVolumeRequest{
+		VolumeId:          "iscsi://10.0.0.1:3260/iqn.2024-01.com.example:static-volume/lun/4?name=static-iscsi-volume",
+		StagingTargetPath: stagingTargetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+			AccessType: &csi.VolumeCapability_Block{Block: &csi.VolumeCapability_BlockVolume{}},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, "iqn.2024-01.com.example:static-volume", gotConnector.TargetIqn)
+	assert.Equal(t, []string{"10.0.0.1:3260"}, gotConnector.TargetPortals)
+	assert.Equal(t, int32(4), gotConnector.Lun)
+}
+
 func TestNodeStageVolume_FilesystemFsType(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -293,7 +359,8 @@ func TestNodeStageVolume_FilesystemFsType(t *testing.T) {
 				VolumeCapability: &csi.VolumeCapability{
 					AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
 					AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{
-						FsType: tt.capabilityFsType,
+						FsType:     tt.capabilityFsType,
+						MountFlags: []string{"rw"},
 					}},
 				},
 				PublishContext: map[string]string{
@@ -309,6 +376,7 @@ func TestNodeStageVolume_FilesystemFsType(t *testing.T) {
 			assert.Equal(t, "/dev/sdb", gotSource)
 			assert.Equal(t, stagingTargetPath, gotTarget)
 			assert.Equal(t, tt.wantFsType, gotFsType)
+			assert.Contains(t, gotOptions, "rw")
 			for _, opt := range tt.wantOptions {
 				assert.Contains(t, gotOptions, opt)
 			}
@@ -325,7 +393,9 @@ func TestNodeStageVolume_NFS(t *testing.T) {
 		StagingTargetPath: stagingTargetPath,
 		VolumeCapability: &csi.VolumeCapability{
 			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
-			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{
+				MountFlags: []string{"sync"},
+			}},
 		},
 		PublishContext: map[string]string{
 			"protocol":      "nfs",
@@ -344,9 +414,37 @@ func TestNodeStageVolume_NFS(t *testing.T) {
 	require.Len(t, mockMount.formatAndMounts, 1)
 	assert.Equal(t, "10.0.0.2:/export/test", mockMount.formatAndMounts[0].source)
 	assert.Equal(t, "nfs", mockMount.formatAndMounts[0].fsType)
+	assert.Contains(t, mockMount.formatAndMounts[0].options, "sync")
 	assert.Contains(t, mockMount.formatAndMounts[0].options, "nfsvers=4.1")
 	assert.Contains(t, mockMount.formatAndMounts[0].options, "vers=4.2")
 	assert.Contains(t, mockMount.formatAndMounts[0].options, "sec=krb5p")
+}
+
+func TestNodeStageVolume_NFSWithoutPublishContextUsesVolumeContext(t *testing.T) {
+	ns, _, mockMount := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+
+	resp, err := ns.NodeStageVolume(context.Background(), &csi.NodeStageVolumeRequest{
+		VolumeId:          "nfs://10.0.0.2/export/test",
+		StagingTargetPath: stagingTargetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+		},
+		VolumeContext: map[string]string{
+			"protocol":               "nfs",
+			"nfsServer":              "10.0.0.4",
+			"nfsExportPath":          "/export/context",
+			"nfsMountAuthentication": "krb5i",
+		},
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	require.Len(t, mockMount.formatAndMounts, 1)
+	assert.Equal(t, "10.0.0.4:/export/context", mockMount.formatAndMounts[0].source)
+	assert.Equal(t, "nfs", mockMount.formatAndMounts[0].fsType)
+	assert.Contains(t, mockMount.formatAndMounts[0].options, "sec=krb5i")
 }
 
 func TestNodeStageVolume_SMB(t *testing.T) {
@@ -386,6 +484,26 @@ func TestNodeStageVolume_SMB(t *testing.T) {
 	assert.Contains(t, mockMount.formatAndMounts[0].options, "password=storage-pass")
 	assert.Contains(t, mockMount.formatAndMounts[0].options, "domain=EXAMPLE")
 	assert.Contains(t, mockMount.formatAndMounts[0].options, "seal")
+}
+
+func TestNodeStageVolume_SMBWithoutPublishContextUsesVolumeID(t *testing.T) {
+	ns, _, mockMount := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+
+	resp, err := ns.NodeStageVolume(context.Background(), &csi.NodeStageVolumeRequest{
+		VolumeId:          "smb://10.0.0.3/share",
+		StagingTargetPath: stagingTargetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	require.Len(t, mockMount.formatAndMounts, 1)
+	assert.Equal(t, "//10.0.0.3/share", mockMount.formatAndMounts[0].source)
+	assert.Equal(t, "cifs", mockMount.formatAndMounts[0].fsType)
 }
 
 // ---------------------------------------------------------------------------
@@ -527,10 +645,10 @@ func TestNodePublishVolume_ParsePublishErrors(t *testing.T) {
 		publishContext map[string]string
 		wantErr        string
 	}{
-		{name: "missing publish context", wantErr: "publishContext is required"},
-		{name: "missing target portal", publishContext: map[string]string{"iqn": "iqn.2024-01.com.example:test", "lun": "0"}, wantErr: "publishContext[targetPortal] missing"},
-		{name: "missing iqn", publishContext: map[string]string{"targetPortal": "10.0.0.1:3260", "lun": "0"}, wantErr: "publishContext[iqn] missing"},
-		{name: "missing lun", publishContext: map[string]string{"targetPortal": "10.0.0.1:3260", "iqn": "iqn.2024-01.com.example:test"}, wantErr: "publishContext[lun] missing"},
+		{name: "missing publish context", wantErr: "targetPortal is required"},
+		{name: "missing target portal", publishContext: map[string]string{"iqn": "iqn.2024-01.com.example:test", "lun": "0"}, wantErr: "targetPortal is required"},
+		{name: "missing iqn", publishContext: map[string]string{"targetPortal": "10.0.0.1:3260", "lun": "0"}, wantErr: "iqn is required"},
+		{name: "missing lun", publishContext: map[string]string{"targetPortal": "10.0.0.1:3260", "iqn": "iqn.2024-01.com.example:test"}, wantErr: "lun is required"},
 		{name: "invalid lun", publishContext: map[string]string{"targetPortal": "10.0.0.1:3260", "iqn": "iqn.2024-01.com.example:test", "lun": "bad"}, wantErr: "invalid lun"},
 	}
 
@@ -550,6 +668,34 @@ func TestNodePublishVolume_ParsePublishErrors(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
+}
+
+func TestNodePublishVolume_StaticISCSIUsesVolumeContextWithoutPublishContext(t *testing.T) {
+	ns, _, mockMount := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+	targetPath := t.TempDir()
+
+	resp, err := ns.NodePublishVolume(context.Background(), &csi.NodePublishVolumeRequest{
+		VolumeId:          "static-iscsi-volume",
+		TargetPath:        targetPath,
+		StagingTargetPath: stagingTargetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{FsType: "ext4"}},
+		},
+		VolumeContext: map[string]string{
+			"targetPortal": "10.0.0.1:3260",
+			"iqn":          "iqn.2024-01.com.example:static-volume",
+			"lun":          "3",
+		},
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	require.Len(t, mockMount.formatAndMounts, 1)
+	assert.Equal(t, stagingTargetPath, mockMount.formatAndMounts[0].source)
+	assert.Equal(t, targetPath, mockMount.formatAndMounts[0].target)
+	assert.Contains(t, mockMount.formatAndMounts[0].options, "bind")
 }
 
 func TestNodePublishVolume_FileShareValidation(t *testing.T) {
@@ -580,6 +726,29 @@ func TestNodePublishVolume_FileShareValidation(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "stagingTargetPath required")
 	})
+}
+
+func TestNodePublishVolume_FileShareWithoutPublishContextUsesVolumeID(t *testing.T) {
+	ns, _, mockMount := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+	targetPath := t.TempDir()
+
+	resp, err := ns.NodePublishVolume(context.Background(), &csi.NodePublishVolumeRequest{
+		VolumeId:          "nfs://10.0.0.2/export/test",
+		TargetPath:        targetPath,
+		StagingTargetPath: stagingTargetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER},
+			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	require.Len(t, mockMount.formatAndMounts, 1)
+	assert.Equal(t, stagingTargetPath, mockMount.formatAndMounts[0].source)
+	assert.Equal(t, targetPath, mockMount.formatAndMounts[0].target)
+	assert.Contains(t, mockMount.formatAndMounts[0].options, "bind")
 }
 
 func TestNodePublishVolume_FilesystemVolume(t *testing.T) {

--- a/pkg/iscsilib/iscsi.go
+++ b/pkg/iscsilib/iscsi.go
@@ -380,7 +380,7 @@ func (c *Connector) discoverTarget(targetIqn string, iFace string, portal string
 		}
 	}
 
-	if c.DoCHAPDiscovery {
+	if c.DoCHAPDiscovery || c.SessionSecrets.SecretsType == "chap" {
 		// Make sure we don't log the secrets
 		err := CreateDBEntry(targetIqn, portal, iFace, c.DiscoverySecrets, c.SessionSecrets)
 		if err != nil {

--- a/pkg/iscsilib/iscsiadm_test.go
+++ b/pkg/iscsilib/iscsiadm_test.go
@@ -176,6 +176,26 @@ func TestDiscoverydb(t *testing.T) {
 	})
 }
 
+func TestConnectorDiscoverTargetWithSessionChapOnly(t *testing.T) {
+	calls := captureExecWithTimeout(t, nil, nil)
+	conn := Connector{
+		DoDiscovery: true,
+		SessionSecrets: Secrets{
+			SecretsType: "chap",
+			UserName:    "session-user",
+			Password:    "session-pass",
+		},
+	}
+
+	require.NoError(t, conn.discoverTarget("iqn.2024-01.com.example:vol", "iface0", "10.0.0.1:3260"))
+	require.Len(t, *calls, 4)
+	assert.Equal(t, []string{"-m", "discoverydb", "-t", "sendtargets", "-p", "10.0.0.1:3260", "-I", "iface0", "-o", "new"}, (*calls)[0].args)
+	assert.Equal(t, []string{"-m", "discoverydb", "-t", "sendtargets", "-p", "10.0.0.1:3260", "-I", "iface0", "--discover"}, (*calls)[1].args)
+	assert.Equal(t, []string{"-m", "node", "-T", "iqn.2024-01.com.example:vol", "-p", "10.0.0.1:3260", "-I", "iface0", "-o", "new"}, (*calls)[2].args)
+	assert.Contains(t, (*calls)[3].args, "node.session.auth.username")
+	assert.Contains(t, (*calls)[3].args, "session-user")
+}
+
 func TestLogin(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		calls := captureExecWithTimeout(t, nil, nil)


### PR DESCRIPTION
Add examples for static and nodeonly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default multi‑driver install (five protocols) with per‑driver enable/disable flags
  * Node‑only installation mode for stateless node installs
  * iSCSI CHAP (including mutual/reverse CHAP) target configuration
  * Installer can auto‑create WinRM secret when needed

* **Documentation**
  * Expanded Helm and manifest deployment guidance, mode‑specific verification steps, and CHAP YAML examples
  * Added node‑only/static PV examples for all protocols

* **Chores**
  * Normalized example sizes and updated install/uninstall flows for node‑only mode
<!-- end of auto-generated comment: release notes by coderabbit.ai -->