### PR TITLE
fix: Ensure deletion occurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ Existing PV objects that reference a legacy `spec.csi.driver` need to be recreat
 
 Each protocol folder under [`examples/`](./examples/) starts with `01-storageclass/` and builds on the PVC names from the previous examples.
 
+### Deletion and Reclaim Policy
+
+Dynamic examples use `reclaimPolicy: Delete`. Static PV import examples use
+`persistentVolumeReclaimPolicy: Retain` so existing storage is not removed by
+Kubernetes.
+
+| Reclaim policy | Kubernetes behavior | Driver cleanup |
+| --- | --- | --- |
+| unset | Kubernetes defaults dynamically provisioned PVs to `Delete`. | Same as `Delete`. |
+| `Delete` | When the PVC is deleted and the PV is released, the external provisioner calls CSI `DeleteVolume`. The PV finalizer remains until the driver returns success. | The driver deletes the Windows-side asset for dynamically provisioned volumes. If cleanup fails, `DeleteVolume` returns an error so Kubernetes retries. |
+| `Retain` | The PV is released for manual reclamation. Deleting the PVC, and later deleting the PV object, does not call CSI `DeleteVolume` for backend deletion. | The Windows-side asset remains. Remove it manually after verifying no workload still needs the data. |
+| `Recycle` | Deprecated Kubernetes PV policy and not a StorageClass reclaim policy for this CSI driver. | Not supported; use `Delete` or `Retain`. |
+
+With `Delete`, protocol-specific cleanup is:
+
+| Mode | What is removed |
+| --- | --- |
+| iSCSI | The node unmounts and logs out during pod teardown. Controller deletion removes the iSCSI target mapping, deletes the VHDX file, then deletes the Windows iSCSI target. |
+| NFS directory | The NFS share and quota are removed, then the backing directory is deleted. |
+| NFS VHDX | The NFS share and quota are removed, the mounted VHDX access path is removed, the VHDX is dismounted, and the VHDX file is deleted. |
+| SMB directory | The SMB share and quota are removed, then the backing directory is deleted. |
+| SMB VHDX | The SMB share and quota are removed, the mounted VHDX access path is removed, the VHDX is dismounted, and the VHDX file is deleted. |
+
 ---
 
 ### Prerequisites

--- a/examples/iscsi/02-filesystem-pvc-pod/README.md
+++ b/examples/iscsi/02-filesystem-pvc-pod/README.md
@@ -1,6 +1,8 @@
 # iSCSI Filesystem PVC and Pod
 
-Creates a 1Gi RWO PVC and runs Postgres mounting it.
+Creates a 1Gi RWO PVC and runs Postgres mounting it. The pod sets `PGDATA` to a
+subdirectory under the mount because PostgreSQL refuses to initialize directly
+on a filesystem root that contains `lost+found`.
 
 ## Apply
 

--- a/examples/iscsi/02-filesystem-pvc-pod/pod.yaml
+++ b/examples/iscsi/02-filesystem-pvc-pod/pod.yaml
@@ -12,6 +12,8 @@ spec:
       env:
         - name: POSTGRES_PASSWORD
           value: example
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
       volumeMounts:
         - name: data
           mountPath: /var/lib/postgresql/data

--- a/pkg/iscsi/backend_fileshare.go
+++ b/pkg/iscsi/backend_fileshare.go
@@ -148,16 +148,28 @@ function Mount-CsiFileShareVirtualDisk([string]$VhdxPath, [string]$MountPath) {
   }
 }
 function Dismount-CsiFileShareVirtualDisk([string]$VhdxPath, [string]$MountPath) {
+  $accessPath = Get-CsiAccessPath $MountPath
   $partition = Get-CsiPartitionByAccessPath $MountPath
   if ($partition) {
-    Remove-PartitionAccessPath -DiskNumber $partition.DiskNumber -PartitionNumber $partition.PartitionNumber -AccessPath (Get-CsiAccessPath $MountPath) -ErrorAction SilentlyContinue
+    Remove-PartitionAccessPath -DiskNumber $partition.DiskNumber -PartitionNumber $partition.PartitionNumber -AccessPath $accessPath -ErrorAction Stop
+    $partition = Get-Partition -DiskNumber $partition.DiskNumber -PartitionNumber $partition.PartitionNumber -ErrorAction SilentlyContinue
+    if ($partition -and @($partition.AccessPaths) -contains $accessPath) {
+      throw "failed to remove partition access path '$accessPath'"
+    }
   }
   $image = Get-DiskImage -ImagePath $VhdxPath -ErrorAction SilentlyContinue
   if ($image -and $image.Attached) {
-    Dismount-DiskImage -ImagePath $VhdxPath -ErrorAction SilentlyContinue
+    Dismount-DiskImage -ImagePath $VhdxPath -ErrorAction Stop
+    $image = Get-DiskImage -ImagePath $VhdxPath -ErrorAction SilentlyContinue
+    if ($image -and $image.Attached) {
+      throw "failed to dismount file-share virtual disk '$VhdxPath'"
+    }
   }
   if ($MountPath -and (Test-Path -LiteralPath $MountPath)) {
-    Remove-Item -LiteralPath $MountPath -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $MountPath -Force -ErrorAction Stop
+    if (Test-Path -LiteralPath $MountPath) {
+      throw "failed to delete file-share mount path '$MountPath'"
+    }
   }
 }
 `
@@ -303,12 +315,25 @@ if ($share -and -not $path) {
   $path = $share.Path
 }
 if ($share) {
-  Remove-NfsShare -Name $name -Confirm:$false -ErrorAction SilentlyContinue
+  Remove-NfsShare -Name $name -Confirm:$false -ErrorAction Stop
+  if (Get-NfsShare -Name $name -ErrorAction SilentlyContinue) {
+    throw "failed to delete NFS share '$name'"
+  }
 }
 if ($path -and (Test-Path -LiteralPath $path)) {
-  if (Get-Command Remove-FsrmQuota -ErrorAction SilentlyContinue) { Remove-FsrmQuota -Path $path -Confirm:$false -ErrorAction SilentlyContinue | Out-Null }
+  if (Get-Command Remove-FsrmQuota -ErrorAction SilentlyContinue) {
+    if (Get-FsrmQuota -Path $path -ErrorAction SilentlyContinue) {
+      Remove-FsrmQuota -Path $path -Confirm:$false -ErrorAction Stop | Out-Null
+      if (Get-FsrmQuota -Path $path -ErrorAction SilentlyContinue) {
+        throw "failed to delete quota for NFS share path '$path'"
+      }
+    }
+  }
   if (-not (Test-CsiPartitionAccessPath $path)) {
-    Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction Stop
+    if (Test-Path -LiteralPath $path) {
+      throw "failed to delete NFS share path '$path'"
+    }
   }
 }
 @{ ok=$true }
@@ -406,12 +431,25 @@ if ($share -and -not $path) {
   $path = $share.Path
 }
 if ($share) {
-  Remove-SmbShare -Name $name -Force -ErrorAction SilentlyContinue
+  Remove-SmbShare -Name $name -Force -ErrorAction Stop
+  if (Get-SmbShare -Name $name -ErrorAction SilentlyContinue) {
+    throw "failed to delete SMB share '$name'"
+  }
 }
 if ($path -and (Test-Path -LiteralPath $path)) {
-  if (Get-Command Remove-FsrmQuota -ErrorAction SilentlyContinue) { Remove-FsrmQuota -Path $path -Confirm:$false -ErrorAction SilentlyContinue | Out-Null }
+  if (Get-Command Remove-FsrmQuota -ErrorAction SilentlyContinue) {
+    if (Get-FsrmQuota -Path $path -ErrorAction SilentlyContinue) {
+      Remove-FsrmQuota -Path $path -Confirm:$false -ErrorAction Stop | Out-Null
+      if (Get-FsrmQuota -Path $path -ErrorAction SilentlyContinue) {
+        throw "failed to delete quota for SMB share path '$path'"
+      }
+    }
+  }
   if (-not (Test-CsiPartitionAccessPath $path)) {
-    Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction Stop
+    if (Test-Path -LiteralPath $path) {
+      throw "failed to delete SMB share path '$path'"
+    }
   }
 }
 @{ ok=$true }

--- a/pkg/iscsi/backend_fileshare.go
+++ b/pkg/iscsi/backend_fileshare.go
@@ -334,6 +334,8 @@ if ($path -and (Test-Path -LiteralPath $path)) {
     if (Test-Path -LiteralPath $path) {
       throw "failed to delete NFS share path '$path'"
     }
+  } else {
+    throw "cannot delete NFS share path '$path' because it is still mounted"
   }
 }
 @{ ok=$true }
@@ -450,6 +452,8 @@ if ($path -and (Test-Path -LiteralPath $path)) {
     if (Test-Path -LiteralPath $path) {
       throw "failed to delete SMB share path '$path'"
     }
+  } else {
+    throw "cannot delete SMB share path '$path' because it is still mounted"
   }
 }
 @{ ok=$true }

--- a/pkg/iscsi/backend_fileshare_test.go
+++ b/pkg/iscsi/backend_fileshare_test.go
@@ -128,6 +128,8 @@ func TestWinRMBackend_DeleteNfsShare(t *testing.T) {
 		assert.Contains(t, script, "-ErrorAction Stop")
 		assert.Contains(t, script, "failed to delete NFS share")
 		assert.Contains(t, script, "failed to delete NFS share path")
+		assert.Contains(t, script, "cannot delete NFS share path")
+		assert.Contains(t, script, "still mounted")
 		assert.NotContains(t, script, "Remove-NfsShare -Name $name -Force")
 		assert.Contains(t, script, "Remove-Item")
 		return nil
@@ -306,6 +308,8 @@ func TestWinRMBackend_DeleteSmbShare(t *testing.T) {
 		assert.Contains(t, script, "-ErrorAction Stop")
 		assert.Contains(t, script, "failed to delete SMB share")
 		assert.Contains(t, script, "failed to delete SMB share path")
+		assert.Contains(t, script, "cannot delete SMB share path")
+		assert.Contains(t, script, "still mounted")
 		assert.Contains(t, script, "Remove-Item")
 		return nil
 	}

--- a/pkg/iscsi/backend_fileshare_test.go
+++ b/pkg/iscsi/backend_fileshare_test.go
@@ -125,6 +125,9 @@ func TestWinRMBackend_DeleteNfsShare(t *testing.T) {
 	backend.psRunner = func(ctx context.Context, script string, out any) error {
 		assert.Contains(t, script, "Remove-NfsShare")
 		assert.Contains(t, script, "-Confirm:$false")
+		assert.Contains(t, script, "-ErrorAction Stop")
+		assert.Contains(t, script, "failed to delete NFS share")
+		assert.Contains(t, script, "failed to delete NFS share path")
 		assert.NotContains(t, script, "Remove-NfsShare -Name $name -Force")
 		assert.Contains(t, script, "Remove-Item")
 		return nil
@@ -300,6 +303,9 @@ func TestWinRMBackend_DeleteSmbShare(t *testing.T) {
 	backend := newUnitWinRMBackend()
 	backend.psRunner = func(ctx context.Context, script string, out any) error {
 		assert.Contains(t, script, "Remove-SmbShare")
+		assert.Contains(t, script, "-ErrorAction Stop")
+		assert.Contains(t, script, "failed to delete SMB share")
+		assert.Contains(t, script, "failed to delete SMB share path")
 		assert.Contains(t, script, "Remove-Item")
 		return nil
 	}
@@ -391,6 +397,9 @@ func TestWinRMBackend_UnmountFileShareVirtualDisk(t *testing.T) {
 	backend.psRunner = func(ctx context.Context, script string, out any) error {
 		assert.Contains(t, script, "Dismount-CsiFileShareVirtualDisk")
 		assert.Contains(t, script, "Remove-PartitionAccessPath")
+		assert.Contains(t, script, "-ErrorAction Stop")
+		assert.Contains(t, script, "failed to remove partition access path")
+		assert.Contains(t, script, "failed to dismount file-share virtual disk")
 		assert.Contains(t, script, "D:\\vhdx\\share.vhdx")
 		assert.Contains(t, script, "D:\\shares\\share")
 		return nil

--- a/pkg/iscsi/backend_winrm.go
+++ b/pkg/iscsi/backend_winrm.go
@@ -384,12 +384,18 @@ if (Get-IscsiVirtualDisk -ComputerName $IscsiTargetComputerName -Path '%s' -Erro
 
 func (b *WinRMBackend) DeleteVirtualDisk(ctx context.Context, vhdxPath string) error {
 	s := fmt.Sprintf(`
-if (Get-IscsiVirtualDisk -ComputerName $IscsiTargetComputerName -Path '%s' -ErrorAction SilentlyContinue) {
-  Remove-IscsiVirtualDisk -ComputerName $IscsiTargetComputerName -Path '%s' -ErrorAction SilentlyContinue
+$path = '%s'
+if (Get-IscsiVirtualDisk -ComputerName $IscsiTargetComputerName -Path $path -ErrorAction SilentlyContinue) {
+  Remove-IscsiVirtualDisk -ComputerName $IscsiTargetComputerName -Path $path -ErrorAction Stop
 }
-if (Test-Path -LiteralPath '%s') { Remove-Item -LiteralPath '%s' -Force -ErrorAction SilentlyContinue }
+if (Test-Path -LiteralPath $path) {
+  Remove-Item -LiteralPath $path -Force -ErrorAction Stop
+}
+if (Test-Path -LiteralPath $path) {
+  throw "failed to delete iSCSI virtual disk file '$path'"
+}
 @{ ok = $true }
-`, escapePS(vhdxPath), escapePS(vhdxPath), escapePS(vhdxPath), escapePS(vhdxPath))
+`, escapePS(vhdxPath))
 	var out map[string]any
 	return b.runPS(ctx, s, &out)
 }

--- a/pkg/iscsi/backend_winrm.go
+++ b/pkg/iscsi/backend_winrm.go
@@ -407,6 +407,29 @@ if (Test-Path -LiteralPath $path) {
 	return b.runPS(ctx, s, &out)
 }
 
+func (b *WinRMBackend) LookupTargetNameByIQN(ctx context.Context, targetIQN string) (string, error) {
+	targetIQN = strings.TrimSpace(targetIQN)
+	if targetIQN == "" {
+		return "", nil
+	}
+	s := fmt.Sprintf(`
+$targetIQN = '%s'
+$target = @(Get-IscsiServerTarget -ComputerName $IscsiTargetComputerName -ErrorAction SilentlyContinue | Where-Object { [string]$_.TargetIqn -eq $targetIQN } | Select-Object -First 1)[0]
+if ($target) {
+  @{ targetName=[string]$target.TargetName }
+} else {
+  @{ targetName='' }
+}
+`, escapePS(targetIQN))
+	var out struct {
+		TargetName string `json:"targetName"`
+	}
+	if err := b.runPS(ctx, s, &out); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.TargetName), nil
+}
+
 func (b *WinRMBackend) DeleteTarget(ctx context.Context, targetName string) error {
 	targetName = strings.TrimSpace(targetName)
 	if targetName == "" {

--- a/pkg/iscsi/backend_winrm.go
+++ b/pkg/iscsi/backend_winrm.go
@@ -373,11 +373,18 @@ if ($mappedTargets -notcontains '%s') {
 
 func (b *WinRMBackend) UnmapDiskFromTarget(ctx context.Context, targetName, vhdxPath string) error {
 	s := fmt.Sprintf(`
-if (Get-IscsiVirtualDisk -ComputerName $IscsiTargetComputerName -Path '%s' -ErrorAction SilentlyContinue) {
-  Remove-IscsiVirtualDiskTargetMapping -ComputerName $IscsiTargetComputerName -TargetName '%s' -Path '%s' -ErrorAction SilentlyContinue
+$targetName = '%s'
+$path = '%s'
+$target = Get-IscsiServerTarget -ComputerName $IscsiTargetComputerName -TargetName $targetName -ErrorAction SilentlyContinue
+if ($target -and @($target.LunMappings | Where-Object { $_.Path -eq $path }).Count -gt 0) {
+  Remove-IscsiVirtualDiskTargetMapping -ComputerName $IscsiTargetComputerName -TargetName $targetName -Path $path -ErrorAction Stop
+  $target = Get-IscsiServerTarget -ComputerName $IscsiTargetComputerName -TargetName $targetName -ErrorAction SilentlyContinue
+  if ($target -and @($target.LunMappings | Where-Object { $_.Path -eq $path }).Count -gt 0) {
+    throw "failed to remove iSCSI target mapping '$targetName' -> '$path'"
+  }
 }
 @{ ok = $true }
-`, escapePS(vhdxPath), escapePS(targetName), escapePS(vhdxPath))
+`, escapePS(targetName), escapePS(vhdxPath))
 	var out map[string]any
 	return b.runPS(ctx, s, &out)
 }
@@ -396,6 +403,29 @@ if (Test-Path -LiteralPath $path) {
 }
 @{ ok = $true }
 `, escapePS(vhdxPath))
+	var out map[string]any
+	return b.runPS(ctx, s, &out)
+}
+
+func (b *WinRMBackend) DeleteTarget(ctx context.Context, targetName string) error {
+	targetName = strings.TrimSpace(targetName)
+	if targetName == "" {
+		return nil
+	}
+	s := fmt.Sprintf(`
+$targetName = '%s'
+$target = Get-IscsiServerTarget -ComputerName $IscsiTargetComputerName -TargetName $targetName -ErrorAction SilentlyContinue
+if ($target) {
+  if (@($target.LunMappings).Count -gt 0) {
+    throw "cannot delete iSCSI target '$targetName' because it still has LUN mappings"
+  }
+  Remove-IscsiServerTarget -ComputerName $IscsiTargetComputerName -TargetName $targetName -Confirm:$false -ErrorAction Stop | Out-Null
+  if (Get-IscsiServerTarget -ComputerName $IscsiTargetComputerName -TargetName $targetName -ErrorAction SilentlyContinue) {
+    throw "failed to delete iSCSI target '$targetName'"
+  }
+}
+@{ ok = $true }
+`, escapePS(targetName))
 	var out map[string]any
 	return b.runPS(ctx, s, &out)
 }

--- a/pkg/iscsi/backend_winrm_test.go
+++ b/pkg/iscsi/backend_winrm_test.go
@@ -603,6 +603,9 @@ func TestWinRMBackend_DeleteVirtualDisk(t *testing.T) {
 			backend := newUnitWinRMBackend()
 			backend.psRunner = func(ctx context.Context, script string, out any) error {
 				assert.Contains(t, script, tt.vhdxPath)
+				assert.Contains(t, script, "Remove-IscsiVirtualDisk")
+				assert.Contains(t, script, "-ErrorAction Stop")
+				assert.Contains(t, script, "failed to delete iSCSI virtual disk file")
 				return tt.psErr
 			}
 

--- a/pkg/iscsi/backend_winrm_test.go
+++ b/pkg/iscsi/backend_winrm_test.go
@@ -617,6 +617,58 @@ func TestWinRMBackend_DeleteTarget(t *testing.T) {
 	}
 }
 
+func TestWinRMBackend_LookupTargetNameByIQN(t *testing.T) {
+	tests := []struct {
+		name       string
+		targetIQN  string
+		psOut      any
+		psErr      error
+		wantTarget string
+		wantErr    bool
+	}{
+		{
+			name:       "target found",
+			targetIQN:  "iqn.1991-05.com.microsoft:win-storage-test-volume",
+			psOut:      struct{ TargetName string }{TargetName: "test-volume"},
+			wantTarget: "test-volume",
+		},
+		{
+			name:      "target missing",
+			targetIQN: "iqn.1991-05.com.microsoft:missing",
+			psOut:     struct{ TargetName string }{},
+		},
+		{
+			name:      "error from PowerShell",
+			targetIQN: "iqn.1991-05.com.microsoft:error",
+			psErr:     errors.New("lookup failed"),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := newUnitWinRMBackend()
+			backend.psRunner = func(ctx context.Context, script string, out any) error {
+				assert.Contains(t, script, tt.targetIQN)
+				assert.Contains(t, script, "Get-IscsiServerTarget")
+				assert.Contains(t, script, "TargetIqn")
+				if out != nil {
+					copyTestOutput(out, tt.psOut)
+				}
+				return tt.psErr
+			}
+
+			targetName, err := backend.LookupTargetNameByIQN(context.Background(), tt.targetIQN)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantTarget, targetName)
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // DeleteVirtualDisk tests
 // ---------------------------------------------------------------------------

--- a/pkg/iscsi/backend_winrm_test.go
+++ b/pkg/iscsi/backend_winrm_test.go
@@ -560,10 +560,54 @@ func TestWinRMBackend_UnmapDiskFromTarget(t *testing.T) {
 			backend.psRunner = func(ctx context.Context, script string, out any) error {
 				assert.Contains(t, script, tt.targetIQN)
 				assert.Contains(t, script, tt.vhdxPath)
+				assert.Contains(t, script, "Remove-IscsiVirtualDiskTargetMapping")
+				assert.Contains(t, script, "-ErrorAction Stop")
+				assert.Contains(t, script, "failed to remove iSCSI target mapping")
 				return tt.psErr
 			}
 
 			err := backend.UnmapDiskFromTarget(context.Background(), tt.targetIQN, tt.vhdxPath)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestWinRMBackend_DeleteTarget(t *testing.T) {
+	tests := []struct {
+		name       string
+		targetName string
+		psErr      error
+		wantErr    bool
+	}{
+		{
+			name:       "happy path",
+			targetName: "target-001",
+		},
+		{
+			name:       "error from PowerShell",
+			targetName: "target-002",
+			psErr:      errors.New("delete target failed"),
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := newUnitWinRMBackend()
+			backend.psRunner = func(ctx context.Context, script string, out any) error {
+				assert.Contains(t, script, tt.targetName)
+				assert.Contains(t, script, "Remove-IscsiServerTarget")
+				assert.Contains(t, script, "-Confirm:$false")
+				assert.Contains(t, script, "-ErrorAction Stop")
+				assert.Contains(t, script, "failed to delete iSCSI target")
+				return tt.psErr
+			}
+
+			err := backend.DeleteTarget(context.Background(), tt.targetName)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/pkg/iscsi/controllerserver.go
+++ b/pkg/iscsi/controllerserver.go
@@ -51,6 +51,7 @@ Assumptions / contracts:
   MapDiskToTarget(ctx, targetName, vhdxPath string) (lun int32, err error)
   UnmapDiskFromTarget(ctx, targetName, vhdxPath string) error
   DeleteVirtualDisk(ctx, vhdxPath string) error
+  LookupTargetNameByIQN(ctx, targetIQN string) (targetName string, err error)
   DeleteTarget(ctx, targetName string) error
   GetVolumeByName(ctx, name, parentDir string) (exists bool, vhdxPath string, sizeBytes int64, targetName string, targetIQN string, lun int32, err error)
   AllowInitiator(ctx, targetName, initiatorIQN string) error
@@ -696,7 +697,7 @@ func decodeAnyVolumeID(id string) (*VolumeID, volID, error) {
 		return v, volID{
 			VolumeName:   v.Name,
 			TargetPortal: v.TargetPortal,
-			TargetName:   firstNonEmpty(v.TargetName, v.TargetIQN),
+			TargetName:   v.TargetName,
 			TargetIQN:    v.TargetIQN,
 			LUN:          int32(v.LUN),
 			VHDXPath:     v.VHDXPath,
@@ -706,9 +707,6 @@ func decodeAnyVolumeID(id string) (*VolumeID, volID, error) {
 	legacy, err := decodeVolID(id)
 	if err != nil {
 		return nil, volID{}, err
-	}
-	if legacy.TargetName == "" {
-		legacy.TargetName = legacy.TargetIQN
 	}
 	return &VolumeID{
 		Name:          legacy.VolumeName,
@@ -732,6 +730,21 @@ func iscsiTargetForVolume(params map[string]string, volName string) (targetName,
 
 func targetNameFromVolID(id volID) string {
 	return firstNonEmpty(id.TargetName, id.TargetIQN)
+}
+
+func (cs *ControllerServer) deleteTargetNameForVolume(ctx context.Context, id volID) (string, error) {
+	if targetName := strings.TrimSpace(id.TargetName); targetName != "" {
+		return targetName, nil
+	}
+	targetIQN := strings.TrimSpace(id.TargetIQN)
+	if targetIQN == "" {
+		return "", nil
+	}
+	targetName, err := cs.Driver.backend.LookupTargetNameByIQN(ctx, targetIQN)
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "LookupTargetNameByIQN: %v", err)
+	}
+	return strings.TrimSpace(targetName), nil
 }
 
 func targetPortalAddress(targetPortal string, portalPort int) string {
@@ -1441,9 +1454,6 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 	switch decoded.Protocol {
 	case ProtocolNFS:
 		sharePath := firstNonEmpty(decoded.SharePath, decoded.VHDXPath)
-		if err := cs.Driver.backend.DeleteNfsShare(ctx, decoded.Name, sharePath); err != nil {
-			return nil, status.Errorf(codes.Internal, "DeleteNfsShare: %v", err)
-		}
 		if decoded.ShareBackend == fileShareBackendVHDX {
 			if decoded.VHDXPath != "" {
 				if err := cs.Driver.backend.UnmountFileShareVirtualDisk(ctx, decoded.VHDXPath, sharePath); err != nil {
@@ -1453,13 +1463,13 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 					return nil, status.Errorf(codes.Internal, "DeleteVirtualDisk: %v", err)
 				}
 			}
+		}
+		if err := cs.Driver.backend.DeleteNfsShare(ctx, decoded.Name, sharePath); err != nil {
+			return nil, status.Errorf(codes.Internal, "DeleteNfsShare: %v", err)
 		}
 		return &csi.DeleteVolumeResponse{}, nil
 	case ProtocolSMB:
 		sharePath := firstNonEmpty(decoded.SharePath, decoded.VHDXPath)
-		if err := cs.Driver.backend.DeleteSmbShare(ctx, decoded.Name, sharePath); err != nil {
-			return nil, status.Errorf(codes.Internal, "DeleteSmbShare: %v", err)
-		}
 		if decoded.ShareBackend == fileShareBackendVHDX {
 			if decoded.VHDXPath != "" {
 				if err := cs.Driver.backend.UnmountFileShareVirtualDisk(ctx, decoded.VHDXPath, sharePath); err != nil {
@@ -1469,6 +1479,9 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 					return nil, status.Errorf(codes.Internal, "DeleteVirtualDisk: %v", err)
 				}
 			}
+		}
+		if err := cs.Driver.backend.DeleteSmbShare(ctx, decoded.Name, sharePath); err != nil {
+			return nil, status.Errorf(codes.Internal, "DeleteSmbShare: %v", err)
 		}
 		return &csi.DeleteVolumeResponse{}, nil
 	}
@@ -1480,11 +1493,15 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		}
 	}
 	if id.VHDXPath != "" {
+		deleteTargetName, err := cs.deleteTargetNameForVolume(ctx, id)
+		if err != nil {
+			return nil, err
+		}
 		if err := cs.Driver.backend.DeleteVirtualDisk(ctx, id.VHDXPath); err != nil {
 			return nil, status.Errorf(codes.Internal, "DeleteVirtualDisk: %v", err)
 		}
-		if targetName := targetNameFromVolID(id); targetName != "" {
-			if err := cs.Driver.backend.DeleteTarget(ctx, targetName); err != nil {
+		if deleteTargetName != "" {
+			if err := cs.Driver.backend.DeleteTarget(ctx, deleteTargetName); err != nil {
 				return nil, status.Errorf(codes.Internal, "DeleteTarget: %v", err)
 			}
 		}

--- a/pkg/iscsi/controllerserver.go
+++ b/pkg/iscsi/controllerserver.go
@@ -51,6 +51,7 @@ Assumptions / contracts:
   MapDiskToTarget(ctx, targetName, vhdxPath string) (lun int32, err error)
   UnmapDiskFromTarget(ctx, targetName, vhdxPath string) error
   DeleteVirtualDisk(ctx, vhdxPath string) error
+  DeleteTarget(ctx, targetName string) error
   GetVolumeByName(ctx, name, parentDir string) (exists bool, vhdxPath string, sizeBytes int64, targetName string, targetIQN string, lun int32, err error)
   AllowInitiator(ctx, targetName, initiatorIQN string) error
   DenyInitiator(ctx, targetName, initiatorIQN string) error
@@ -1441,15 +1442,15 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 	case ProtocolNFS:
 		sharePath := firstNonEmpty(decoded.SharePath, decoded.VHDXPath)
 		if err := cs.Driver.backend.DeleteNfsShare(ctx, decoded.Name, sharePath); err != nil {
-			klog.Warningf("DeleteNfsShare: %v", err)
+			return nil, status.Errorf(codes.Internal, "DeleteNfsShare: %v", err)
 		}
 		if decoded.ShareBackend == fileShareBackendVHDX {
 			if decoded.VHDXPath != "" {
 				if err := cs.Driver.backend.UnmountFileShareVirtualDisk(ctx, decoded.VHDXPath, sharePath); err != nil {
-					klog.Warningf("UnmountFileShareVirtualDisk: %v", err)
+					return nil, status.Errorf(codes.Internal, "UnmountFileShareVirtualDisk: %v", err)
 				}
 				if err := cs.Driver.backend.DeleteVirtualDisk(ctx, decoded.VHDXPath); err != nil {
-					klog.Warningf("DeleteVirtualDisk: %v", err)
+					return nil, status.Errorf(codes.Internal, "DeleteVirtualDisk: %v", err)
 				}
 			}
 		}
@@ -1457,15 +1458,15 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 	case ProtocolSMB:
 		sharePath := firstNonEmpty(decoded.SharePath, decoded.VHDXPath)
 		if err := cs.Driver.backend.DeleteSmbShare(ctx, decoded.Name, sharePath); err != nil {
-			klog.Warningf("DeleteSmbShare: %v", err)
+			return nil, status.Errorf(codes.Internal, "DeleteSmbShare: %v", err)
 		}
 		if decoded.ShareBackend == fileShareBackendVHDX {
 			if decoded.VHDXPath != "" {
 				if err := cs.Driver.backend.UnmountFileShareVirtualDisk(ctx, decoded.VHDXPath, sharePath); err != nil {
-					klog.Warningf("UnmountFileShareVirtualDisk: %v", err)
+					return nil, status.Errorf(codes.Internal, "UnmountFileShareVirtualDisk: %v", err)
 				}
 				if err := cs.Driver.backend.DeleteVirtualDisk(ctx, decoded.VHDXPath); err != nil {
-					klog.Warningf("DeleteVirtualDisk: %v", err)
+					return nil, status.Errorf(codes.Internal, "DeleteVirtualDisk: %v", err)
 				}
 			}
 		}
@@ -1481,6 +1482,11 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 	if id.VHDXPath != "" {
 		if err := cs.Driver.backend.DeleteVirtualDisk(ctx, id.VHDXPath); err != nil {
 			return nil, status.Errorf(codes.Internal, "DeleteVirtualDisk: %v", err)
+		}
+		if targetName := targetNameFromVolID(id); targetName != "" {
+			if err := cs.Driver.backend.DeleteTarget(ctx, targetName); err != nil {
+				return nil, status.Errorf(codes.Internal, "DeleteTarget: %v", err)
+			}
 		}
 	}
 	return &csi.DeleteVolumeResponse{}, nil

--- a/pkg/iscsi/controllerserver.go
+++ b/pkg/iscsi/controllerserver.go
@@ -1471,15 +1471,16 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		}
 		return &csi.DeleteVolumeResponse{}, nil
 	}
-	// best-effort unmap + delete
+	// Unmap before deleting the backing VHDX. Returning errors keeps the PV
+	// finalizer retrying if a node still has the iSCSI session attached.
 	if targetName := targetNameFromVolID(id); targetName != "" && id.VHDXPath != "" {
 		if err := cs.Driver.backend.UnmapDiskFromTarget(ctx, targetName, id.VHDXPath); err != nil {
-			klog.Warningf("UnmapDiskFromTarget: %v", err)
+			return nil, status.Errorf(codes.Internal, "UnmapDiskFromTarget: %v", err)
 		}
 	}
 	if id.VHDXPath != "" {
 		if err := cs.Driver.backend.DeleteVirtualDisk(ctx, id.VHDXPath); err != nil {
-			klog.Warningf("DeleteVirtualDisk: %v", err)
+			return nil, status.Errorf(codes.Internal, "DeleteVirtualDisk: %v", err)
 		}
 	}
 	return &csi.DeleteVolumeResponse{}, nil
@@ -1549,7 +1550,7 @@ func (cs *ControllerServer) ControllerUnpublishVolume(ctx context.Context, req *
 	}
 	if targetName := targetNameFromVolID(id); targetName != "" {
 		if err := cs.Driver.backend.DenyInitiator(ctx, targetName, req.GetNodeId()); err != nil {
-			klog.Warningf("DenyInitiator: %v", err)
+			return nil, status.Errorf(codes.Internal, "DenyInitiator: %v", err)
 		}
 	} else {
 		klog.Warningf("DenyInitiator: volume_id is missing target name")

--- a/pkg/iscsi/controllerserver_test.go
+++ b/pkg/iscsi/controllerserver_test.go
@@ -21,6 +21,7 @@ type mockBackend struct {
 	mapDiskToTargetFn           func(ctx context.Context, targetName, vhdxPath string) (int32, error)
 	unmapDiskFromTargetFn       func(ctx context.Context, targetName, vhdxPath string) error
 	deleteVirtualDiskFn         func(ctx context.Context, vhdxPath string) error
+	deleteTargetFn              func(ctx context.Context, targetName string) error
 	getVolumeByNameFn           func(ctx context.Context, name, parentDir string) (bool, string, int64, string, string, int32, error)
 	allowInitiatorFn            func(ctx context.Context, targetName, initiatorIQN string) error
 	denyInitiatorFn             func(ctx context.Context, targetName, initiatorIQN string) error
@@ -79,6 +80,12 @@ func (m *mockBackend) UnmapDiskFromTarget(ctx context.Context, targetName, vhdxP
 func (m *mockBackend) DeleteVirtualDisk(ctx context.Context, vhdxPath string) error {
 	if m.deleteVirtualDiskFn != nil {
 		return m.deleteVirtualDiskFn(ctx, vhdxPath)
+	}
+	return nil
+}
+func (m *mockBackend) DeleteTarget(ctx context.Context, targetName string) error {
+	if m.deleteTargetFn != nil {
+		return m.deleteTargetFn(ctx, targetName)
 	}
 	return nil
 }
@@ -1497,6 +1504,29 @@ func TestDeleteVolume_ReturnsErrorWhenDeleteVirtualDiskFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "DeleteVirtualDisk")
 }
 
+func TestDeleteVolume_ReturnsErrorWhenDeleteTargetFails(t *testing.T) {
+	cs, _, mockBackend := newTestControllerServer(t)
+
+	mockBackend.unmapDiskFromTargetFn = func(ctx context.Context, targetName, vhdxPath string) error {
+		return nil
+	}
+	mockBackend.deleteVirtualDiskFn = func(ctx context.Context, vhdxPath string) error {
+		return nil
+	}
+	mockBackend.deleteTargetFn = func(ctx context.Context, targetName string) error {
+		assert.Equal(t, "iqn.2024-01.com.example:test-volume", targetName)
+		return errors.New("target still has initiators")
+	}
+
+	resp, err := cs.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{
+		VolumeId: newTestVolumeID(t),
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "DeleteTarget")
+}
+
 func TestDeleteVolume_NFS(t *testing.T) {
 	cs, _, mockBackend := newTestControllerServer(t)
 	vid := EncodeVolumeID(&VolumeID{Name: "nfs-vol", Protocol: ProtocolNFS, NfsServer: "10.0.0.2", NfsExportPath: "/nfs-vol"})
@@ -1508,6 +1538,20 @@ func TestDeleteVolume_NFS(t *testing.T) {
 	resp, err := cs.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{VolumeId: vid})
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
+}
+
+func TestDeleteVolume_NFSReturnsErrorWhenDeleteShareFails(t *testing.T) {
+	cs, _, mockBackend := newTestControllerServer(t)
+	vid := EncodeVolumeID(&VolumeID{Name: "nfs-vol", Protocol: ProtocolNFS, SharePath: "D:\\shares\\nfs-vol", NfsServer: "10.0.0.2", NfsExportPath: "/nfs-vol"})
+	mockBackend.deleteNfsShareFn = func(ctx context.Context, name, path string) error {
+		return errors.New("remove nfs share failed")
+	}
+
+	resp, err := cs.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{VolumeId: vid})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "DeleteNfsShare")
 }
 
 func TestDeleteVolume_VHDXBackedNFSUnmountsAndDeletes(t *testing.T) {
@@ -1548,6 +1592,35 @@ func TestDeleteVolume_VHDXBackedNFSUnmountsAndDeletes(t *testing.T) {
 	assert.True(t, deletedDisk)
 }
 
+func TestDeleteVolume_VHDXBackedNFSReturnsErrorWhenUnmountFails(t *testing.T) {
+	cs, _, mockBackend := newTestControllerServerForProtocolAndBackend(t, ProtocolNFS, fileShareBackendVHDX)
+	vid := EncodeVolumeID(&VolumeID{
+		Name:          "nfs-vhdx",
+		Protocol:      ProtocolNFS,
+		ShareBackend:  fileShareBackendVHDX,
+		SharePath:     "D:\\shares\\nfs-vhdx",
+		NfsServer:     "10.0.0.2",
+		NfsExportPath: "/nfs-vhdx",
+		VHDXPath:      "D:\\nfs-vhdx\\nfs-vhdx.vhdx",
+	})
+	mockBackend.deleteNfsShareFn = func(ctx context.Context, name, path string) error {
+		return nil
+	}
+	mockBackend.unmountFileShareVhdxFn = func(ctx context.Context, vhdxPath, mountPath string) error {
+		return errors.New("dismount failed")
+	}
+	mockBackend.deleteVirtualDiskFn = func(ctx context.Context, vhdxPath string) error {
+		t.Fatal("DeleteVirtualDisk should not be called after unmount fails")
+		return nil
+	}
+
+	resp, err := cs.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{VolumeId: vid})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "UnmountFileShareVirtualDisk")
+}
+
 func TestDeleteVolume_VHDXBackedSMBUnmountsAndDeletes(t *testing.T) {
 	cs, _, mockBackend := newTestControllerServerForProtocolAndBackend(t, ProtocolSMB, fileShareBackendVHDX)
 	vid := EncodeVolumeID(&VolumeID{
@@ -1584,6 +1657,48 @@ func TestDeleteVolume_VHDXBackedSMBUnmountsAndDeletes(t *testing.T) {
 	assert.True(t, deletedShare)
 	assert.True(t, unmounted)
 	assert.True(t, deletedDisk)
+}
+
+func TestDeleteVolume_SMBReturnsErrorWhenDeleteShareFails(t *testing.T) {
+	cs, _, mockBackend := newTestControllerServerForProtocolAndBackend(t, ProtocolSMB, fileShareBackendDirectory)
+	vid := EncodeVolumeID(&VolumeID{Name: "smb-vol", Protocol: ProtocolSMB, SharePath: "D:\\shares\\smb-vol", SmbServer: "10.0.0.3", SmbShareName: "smb-vol"})
+	mockBackend.deleteSmbShareFn = func(ctx context.Context, name, path string) error {
+		return errors.New("remove smb share failed")
+	}
+
+	resp, err := cs.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{VolumeId: vid})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "DeleteSmbShare")
+}
+
+func TestDeleteVolume_VHDXBackedSMBReturnsErrorWhenDeleteDiskFails(t *testing.T) {
+	cs, _, mockBackend := newTestControllerServerForProtocolAndBackend(t, ProtocolSMB, fileShareBackendVHDX)
+	vid := EncodeVolumeID(&VolumeID{
+		Name:         "smb-vhdx",
+		Protocol:     ProtocolSMB,
+		ShareBackend: fileShareBackendVHDX,
+		SharePath:    "D:\\shares\\smb-vhdx",
+		SmbServer:    "10.0.0.3",
+		SmbShareName: "smb-vhdx",
+		VHDXPath:     "D:\\smb-vhdx\\smb-vhdx.vhdx",
+	})
+	mockBackend.deleteSmbShareFn = func(ctx context.Context, name, path string) error {
+		return nil
+	}
+	mockBackend.unmountFileShareVhdxFn = func(ctx context.Context, vhdxPath, mountPath string) error {
+		return nil
+	}
+	mockBackend.deleteVirtualDiskFn = func(ctx context.Context, vhdxPath string) error {
+		return errors.New("remove vhdx failed")
+	}
+
+	resp, err := cs.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{VolumeId: vid})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "DeleteVirtualDisk")
 }
 
 func TestControllerPublishVolume_SMB(t *testing.T) {

--- a/pkg/iscsi/controllerserver_test.go
+++ b/pkg/iscsi/controllerserver_test.go
@@ -1458,6 +1458,45 @@ func TestDeleteVolume_UsesTargetNameWhenPresent(t *testing.T) {
 	assert.NotNil(t, resp)
 }
 
+func TestDeleteVolume_ReturnsErrorWhenUnmapFails(t *testing.T) {
+	cs, _, mockBackend := newTestControllerServer(t)
+
+	mockBackend.unmapDiskFromTargetFn = func(ctx context.Context, targetName, vhdxPath string) error {
+		return errors.New("node session still attached")
+	}
+	mockBackend.deleteVirtualDiskFn = func(ctx context.Context, vhdxPath string) error {
+		t.Fatal("DeleteVirtualDisk should not be called after UnmapDiskFromTarget fails")
+		return nil
+	}
+
+	resp, err := cs.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{
+		VolumeId: newTestVolumeID(t),
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "UnmapDiskFromTarget")
+}
+
+func TestDeleteVolume_ReturnsErrorWhenDeleteVirtualDiskFails(t *testing.T) {
+	cs, _, mockBackend := newTestControllerServer(t)
+
+	mockBackend.unmapDiskFromTargetFn = func(ctx context.Context, targetName, vhdxPath string) error {
+		return nil
+	}
+	mockBackend.deleteVirtualDiskFn = func(ctx context.Context, vhdxPath string) error {
+		return errors.New("file is still in use")
+	}
+
+	resp, err := cs.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{
+		VolumeId: newTestVolumeID(t),
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "DeleteVirtualDisk")
+}
+
 func TestDeleteVolume_NFS(t *testing.T) {
 	cs, _, mockBackend := newTestControllerServer(t)
 	vid := EncodeVolumeID(&VolumeID{Name: "nfs-vol", Protocol: ProtocolNFS, NfsServer: "10.0.0.2", NfsExportPath: "/nfs-vol"})
@@ -1740,6 +1779,23 @@ func TestControllerUnpublishVolume_UsesTargetNameWhenPresent(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
+}
+
+func TestControllerUnpublishVolume_ReturnsErrorWhenDenyInitiatorFails(t *testing.T) {
+	cs, _, mockBackend := newTestControllerServer(t)
+
+	mockBackend.denyInitiatorFn = func(ctx context.Context, targetName, initiatorIQN string) error {
+		return errors.New("deny failed")
+	}
+
+	resp, err := cs.ControllerUnpublishVolume(context.Background(), &csi.ControllerUnpublishVolumeRequest{
+		VolumeId: newTestVolumeIDWithTargetName(t),
+		NodeId:   "iqn.2024-01.com.example:node-001",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "DenyInitiator")
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/iscsi/controllerserver_test.go
+++ b/pkg/iscsi/controllerserver_test.go
@@ -21,6 +21,7 @@ type mockBackend struct {
 	mapDiskToTargetFn           func(ctx context.Context, targetName, vhdxPath string) (int32, error)
 	unmapDiskFromTargetFn       func(ctx context.Context, targetName, vhdxPath string) error
 	deleteVirtualDiskFn         func(ctx context.Context, vhdxPath string) error
+	lookupTargetNameByIQNFn     func(ctx context.Context, targetIQN string) (string, error)
 	deleteTargetFn              func(ctx context.Context, targetName string) error
 	getVolumeByNameFn           func(ctx context.Context, name, parentDir string) (bool, string, int64, string, string, int32, error)
 	allowInitiatorFn            func(ctx context.Context, targetName, initiatorIQN string) error
@@ -82,6 +83,12 @@ func (m *mockBackend) DeleteVirtualDisk(ctx context.Context, vhdxPath string) er
 		return m.deleteVirtualDiskFn(ctx, vhdxPath)
 	}
 	return nil
+}
+func (m *mockBackend) LookupTargetNameByIQN(ctx context.Context, targetIQN string) (string, error) {
+	if m.lookupTargetNameByIQNFn != nil {
+		return m.lookupTargetNameByIQNFn(ctx, targetIQN)
+	}
+	return "", nil
 }
 func (m *mockBackend) DeleteTarget(ctx context.Context, targetName string) error {
 	if m.deleteTargetFn != nil {
@@ -1456,6 +1463,14 @@ func TestDeleteVolume_UsesTargetNameWhenPresent(t *testing.T) {
 		assert.Equal(t, "D:\\vhdx\\test-volume.vhdx", vhdxPath)
 		return nil
 	}
+	mockBackend.lookupTargetNameByIQNFn = func(ctx context.Context, targetIQN string) (string, error) {
+		t.Fatal("LookupTargetNameByIQN should not be called when targetName is persisted")
+		return "", nil
+	}
+	mockBackend.deleteTargetFn = func(ctx context.Context, targetName string) error {
+		assert.Equal(t, "test-volume", targetName)
+		return nil
+	}
 
 	resp, err := cs.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{
 		VolumeId: newTestVolumeIDWithTargetName(t),
@@ -1513,8 +1528,12 @@ func TestDeleteVolume_ReturnsErrorWhenDeleteTargetFails(t *testing.T) {
 	mockBackend.deleteVirtualDiskFn = func(ctx context.Context, vhdxPath string) error {
 		return nil
 	}
+	mockBackend.lookupTargetNameByIQNFn = func(ctx context.Context, targetIQN string) (string, error) {
+		assert.Equal(t, "iqn.2024-01.com.example:test-volume", targetIQN)
+		return "test-volume", nil
+	}
 	mockBackend.deleteTargetFn = func(ctx context.Context, targetName string) error {
-		assert.Equal(t, "iqn.2024-01.com.example:test-volume", targetName)
+		assert.Equal(t, "test-volume", targetName)
 		return errors.New("target still has initiators")
 	}
 
@@ -1525,6 +1544,44 @@ func TestDeleteVolume_ReturnsErrorWhenDeleteTargetFails(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, resp)
 	assert.Contains(t, err.Error(), "DeleteTarget")
+}
+
+func TestDeleteVolume_LegacyGeneratedIQNLooksUpTargetNameBeforeDeleteTarget(t *testing.T) {
+	cs, _, mockBackend := newTestControllerServer(t)
+	vid := encodeVolID(volID{
+		VolumeName:   "test-volume",
+		TargetPortal: "10.0.0.1:3260",
+		TargetIQN:    "iqn.1991-05.com.microsoft:win-storage-test-volume",
+		LUN:          0,
+		VHDXPath:     "D:\\vhdx\\test-volume.vhdx",
+		SizeBytes:    1073741824,
+	})
+	calls := []string{}
+	mockBackend.unmapDiskFromTargetFn = func(ctx context.Context, targetName, vhdxPath string) error {
+		assert.Equal(t, "iqn.1991-05.com.microsoft:win-storage-test-volume", targetName)
+		calls = append(calls, "unmap")
+		return nil
+	}
+	mockBackend.lookupTargetNameByIQNFn = func(ctx context.Context, targetIQN string) (string, error) {
+		assert.Equal(t, "iqn.1991-05.com.microsoft:win-storage-test-volume", targetIQN)
+		calls = append(calls, "lookup")
+		return "test-volume", nil
+	}
+	mockBackend.deleteVirtualDiskFn = func(ctx context.Context, vhdxPath string) error {
+		calls = append(calls, "delete-disk")
+		return nil
+	}
+	mockBackend.deleteTargetFn = func(ctx context.Context, targetName string) error {
+		assert.Equal(t, "test-volume", targetName)
+		calls = append(calls, "delete-target")
+		return nil
+	}
+
+	resp, err := cs.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{VolumeId: vid})
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, []string{"unmap", "lookup", "delete-disk", "delete-target"}, calls)
 }
 
 func TestDeleteVolume_NFS(t *testing.T) {
@@ -1566,21 +1623,25 @@ func TestDeleteVolume_VHDXBackedNFSUnmountsAndDeletes(t *testing.T) {
 		VHDXPath:      "D:\\nfs-vhdx\\nfs-vhdx.vhdx",
 	})
 	var deletedShare, unmounted, deletedDisk bool
+	calls := []string{}
 	mockBackend.deleteNfsShareFn = func(ctx context.Context, name, path string) error {
 		assert.Equal(t, "nfs-vhdx", name)
 		assert.Equal(t, "D:\\shares\\nfs-vhdx", path)
 		deletedShare = true
+		calls = append(calls, "delete-share")
 		return nil
 	}
 	mockBackend.unmountFileShareVhdxFn = func(ctx context.Context, vhdxPath, mountPath string) error {
 		assert.Equal(t, "D:\\nfs-vhdx\\nfs-vhdx.vhdx", vhdxPath)
 		assert.Equal(t, "D:\\shares\\nfs-vhdx", mountPath)
 		unmounted = true
+		calls = append(calls, "unmount")
 		return nil
 	}
 	mockBackend.deleteVirtualDiskFn = func(ctx context.Context, vhdxPath string) error {
 		assert.Equal(t, "D:\\nfs-vhdx\\nfs-vhdx.vhdx", vhdxPath)
 		deletedDisk = true
+		calls = append(calls, "delete-disk")
 		return nil
 	}
 
@@ -1590,6 +1651,7 @@ func TestDeleteVolume_VHDXBackedNFSUnmountsAndDeletes(t *testing.T) {
 	assert.True(t, deletedShare)
 	assert.True(t, unmounted)
 	assert.True(t, deletedDisk)
+	assert.Equal(t, []string{"unmount", "delete-disk", "delete-share"}, calls)
 }
 
 func TestDeleteVolume_VHDXBackedNFSReturnsErrorWhenUnmountFails(t *testing.T) {
@@ -1603,14 +1665,15 @@ func TestDeleteVolume_VHDXBackedNFSReturnsErrorWhenUnmountFails(t *testing.T) {
 		NfsExportPath: "/nfs-vhdx",
 		VHDXPath:      "D:\\nfs-vhdx\\nfs-vhdx.vhdx",
 	})
-	mockBackend.deleteNfsShareFn = func(ctx context.Context, name, path string) error {
-		return nil
-	}
 	mockBackend.unmountFileShareVhdxFn = func(ctx context.Context, vhdxPath, mountPath string) error {
 		return errors.New("dismount failed")
 	}
 	mockBackend.deleteVirtualDiskFn = func(ctx context.Context, vhdxPath string) error {
 		t.Fatal("DeleteVirtualDisk should not be called after unmount fails")
+		return nil
+	}
+	mockBackend.deleteNfsShareFn = func(ctx context.Context, name, path string) error {
+		t.Fatal("DeleteNfsShare should not be called after unmount fails")
 		return nil
 	}
 
@@ -1633,21 +1696,25 @@ func TestDeleteVolume_VHDXBackedSMBUnmountsAndDeletes(t *testing.T) {
 		VHDXPath:     "D:\\smb-vhdx\\smb-vhdx.vhdx",
 	})
 	var deletedShare, unmounted, deletedDisk bool
+	calls := []string{}
 	mockBackend.deleteSmbShareFn = func(ctx context.Context, name, path string) error {
 		assert.Equal(t, "smb-vhdx", name)
 		assert.Equal(t, "D:\\shares\\smb-vhdx", path)
 		deletedShare = true
+		calls = append(calls, "delete-share")
 		return nil
 	}
 	mockBackend.unmountFileShareVhdxFn = func(ctx context.Context, vhdxPath, mountPath string) error {
 		assert.Equal(t, "D:\\smb-vhdx\\smb-vhdx.vhdx", vhdxPath)
 		assert.Equal(t, "D:\\shares\\smb-vhdx", mountPath)
 		unmounted = true
+		calls = append(calls, "unmount")
 		return nil
 	}
 	mockBackend.deleteVirtualDiskFn = func(ctx context.Context, vhdxPath string) error {
 		assert.Equal(t, "D:\\smb-vhdx\\smb-vhdx.vhdx", vhdxPath)
 		deletedDisk = true
+		calls = append(calls, "delete-disk")
 		return nil
 	}
 
@@ -1657,6 +1724,7 @@ func TestDeleteVolume_VHDXBackedSMBUnmountsAndDeletes(t *testing.T) {
 	assert.True(t, deletedShare)
 	assert.True(t, unmounted)
 	assert.True(t, deletedDisk)
+	assert.Equal(t, []string{"unmount", "delete-disk", "delete-share"}, calls)
 }
 
 func TestDeleteVolume_SMBReturnsErrorWhenDeleteShareFails(t *testing.T) {
@@ -1684,14 +1752,15 @@ func TestDeleteVolume_VHDXBackedSMBReturnsErrorWhenDeleteDiskFails(t *testing.T)
 		SmbShareName: "smb-vhdx",
 		VHDXPath:     "D:\\smb-vhdx\\smb-vhdx.vhdx",
 	})
-	mockBackend.deleteSmbShareFn = func(ctx context.Context, name, path string) error {
-		return nil
-	}
 	mockBackend.unmountFileShareVhdxFn = func(ctx context.Context, vhdxPath, mountPath string) error {
 		return nil
 	}
 	mockBackend.deleteVirtualDiskFn = func(ctx context.Context, vhdxPath string) error {
 		return errors.New("remove vhdx failed")
+	}
+	mockBackend.deleteSmbShareFn = func(ctx context.Context, name, path string) error {
+		t.Fatal("DeleteSmbShare should not be called after delete disk fails")
+		return nil
 	}
 
 	resp, err := cs.DeleteVolume(context.Background(), &csi.DeleteVolumeRequest{VolumeId: vid})

--- a/pkg/iscsi/driver.go
+++ b/pkg/iscsi/driver.go
@@ -38,6 +38,7 @@ type Backend interface {
 	MapDiskToTarget(ctx context.Context, targetName, vhdxPath string) (int32, error)
 	UnmapDiskFromTarget(ctx context.Context, targetName, vhdxPath string) error
 	DeleteVirtualDisk(ctx context.Context, vhdxPath string) error
+	LookupTargetNameByIQN(ctx context.Context, targetIQN string) (string, error)
 	DeleteTarget(ctx context.Context, targetName string) error
 	GetVolumeByName(ctx context.Context, name, parentDir string) (bool, string, int64, string, string, int32, error)
 	AllowInitiator(ctx context.Context, targetName, initiatorIQN string) error

--- a/pkg/iscsi/driver.go
+++ b/pkg/iscsi/driver.go
@@ -38,6 +38,7 @@ type Backend interface {
 	MapDiskToTarget(ctx context.Context, targetName, vhdxPath string) (int32, error)
 	UnmapDiskFromTarget(ctx context.Context, targetName, vhdxPath string) error
 	DeleteVirtualDisk(ctx context.Context, vhdxPath string) error
+	DeleteTarget(ctx context.Context, targetName string) error
 	GetVolumeByName(ctx context.Context, name, parentDir string) (bool, string, int64, string, string, int32, error)
 	AllowInitiator(ctx context.Context, targetName, initiatorIQN string) error
 	DenyInitiator(ctx context.Context, targetName, initiatorIQN string) error

--- a/pkg/iscsi/mock_backend_test.go
+++ b/pkg/iscsi/mock_backend_test.go
@@ -65,6 +65,12 @@ func (m *MockBackend) DeleteVirtualDisk(ctx context.Context, vhdxPath string) er
 	return args.Error(0)
 }
 
+// DeleteTarget mocks DeleteTarget.
+func (m *MockBackend) DeleteTarget(ctx context.Context, targetName string) error {
+	args := m.Called(ctx, targetName)
+	return args.Error(0)
+}
+
 // GetVolumeByName mocks GetVolumeByName.
 func (m *MockBackend) GetVolumeByName(ctx context.Context, name, parentDir string) (bool, string, int64, string, string, int32, error) {
 	args := m.Called(ctx, name, parentDir)
@@ -235,6 +241,16 @@ func TestMockBackend_DeleteVirtualDisk(t *testing.T) {
 	m.On("DeleteVirtualDisk", mock.Anything, "D:\\vhdx\\test-vol.vhdx").Return(nil)
 
 	err := m.DeleteVirtualDisk(context.Background(), "D:\\vhdx\\test-vol.vhdx")
+	assert.NoError(t, err)
+
+	m.AssertExpectations(t)
+}
+
+func TestMockBackend_DeleteTarget(t *testing.T) {
+	m := new(MockBackend)
+	m.On("DeleteTarget", mock.Anything, "target-test").Return(nil)
+
+	err := m.DeleteTarget(context.Background(), "target-test")
 	assert.NoError(t, err)
 
 	m.AssertExpectations(t)

--- a/pkg/iscsi/mock_backend_test.go
+++ b/pkg/iscsi/mock_backend_test.go
@@ -65,6 +65,12 @@ func (m *MockBackend) DeleteVirtualDisk(ctx context.Context, vhdxPath string) er
 	return args.Error(0)
 }
 
+// LookupTargetNameByIQN mocks LookupTargetNameByIQN.
+func (m *MockBackend) LookupTargetNameByIQN(ctx context.Context, targetIQN string) (string, error) {
+	args := m.Called(ctx, targetIQN)
+	return args.String(0), args.Error(1)
+}
+
 // DeleteTarget mocks DeleteTarget.
 func (m *MockBackend) DeleteTarget(ctx context.Context, targetName string) error {
 	args := m.Called(ctx, targetName)
@@ -242,6 +248,17 @@ func TestMockBackend_DeleteVirtualDisk(t *testing.T) {
 
 	err := m.DeleteVirtualDisk(context.Background(), "D:\\vhdx\\test-vol.vhdx")
 	assert.NoError(t, err)
+
+	m.AssertExpectations(t)
+}
+
+func TestMockBackend_LookupTargetNameByIQN(t *testing.T) {
+	m := new(MockBackend)
+	m.On("LookupTargetNameByIQN", mock.Anything, "iqn.1991-05.com.microsoft:server-test-vol").Return("test-vol", nil)
+
+	targetName, err := m.LookupTargetNameByIQN(context.Background(), "iqn.1991-05.com.microsoft:server-test-vol")
+	assert.NoError(t, err)
+	assert.Equal(t, "test-vol", targetName)
 
 	m.AssertExpectations(t)
 }

--- a/pkg/iscsi/nodeserver.go
+++ b/pkg/iscsi/nodeserver.go
@@ -2,6 +2,8 @@ package iscsi
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -198,9 +200,66 @@ func getConnectorFromStaging(staging string, includeLegacy bool) (*iscsilib.Conn
 		if err == nil {
 			return conn, path, nil
 		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, "", err
+		}
 		lastErr = err
 	}
 	return nil, "", lastErr
+}
+
+func getCleanupConnectorFromStaging(staging string, includeLegacy bool) (*iscsilib.Connector, string, error) {
+	paths := []string{stageConnectorFile(staging)}
+	if includeLegacy {
+		paths = append(paths, legacyStageConnectorFile(staging))
+	}
+	var lastErr error
+	for _, path := range paths {
+		conn, err := getConnectorFromFile(path)
+		if err == nil {
+			return conn, path, nil
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			lastErr = err
+			continue
+		}
+		if !isMissingMountTargetDevice(err) {
+			return nil, "", err
+		}
+		conn, staleErr := readPersistedConnector(path)
+		if staleErr != nil {
+			if errors.Is(staleErr, os.ErrNotExist) {
+				lastErr = staleErr
+				continue
+			}
+			return nil, "", staleErr
+		}
+		return conn, path, nil
+	}
+	return nil, "", lastErr
+}
+
+func readPersistedConnector(path string) (*iscsilib.Connector, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	conn := iscsilib.Connector{}
+	if err := json.Unmarshal(raw, &conn); err != nil {
+		return nil, err
+	}
+	if conn.MountTargetDevice == nil {
+		return nil, fmt.Errorf("mountTargetDevice in the connector is nil")
+	}
+	return &conn, nil
+}
+
+func isMissingMountTargetDevice(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "mounttargetdevice") && strings.Contains(msg, "not found")
 }
 
 func removeStagingConnectorFiles(staging string) error {
@@ -531,6 +590,10 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, status.Errorf(codes.Internal, "mkdir iSCSI connector directory: %v", err)
 	}
 	if err := conn.Persist(connectorFile); err != nil {
+		cleanupErr := errors.Join(disconnectVolume(conn), iscsilibDisconnect(conn))
+		if cleanupErr != nil {
+			return nil, status.Errorf(codes.Internal, "persist iSCSI connector: %v (rollback disconnect failed: %v)", err, cleanupErr)
+		}
 		return nil, status.Errorf(codes.Internal, "persist iSCSI connector: %v", err)
 	}
 
@@ -571,20 +634,32 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 	}
 
 	staging := req.GetStagingTargetPath()
-	conn, _, _ := getConnectorFromStaging(staging, false)
-
-	notMnt, err := ns.mounter.IsLikelyNotMountPoint(staging)
-	if err != nil && !os.IsNotExist(err) {
-		return nil, status.Errorf(codes.Internal, "check staging mount: %v", err)
+	conn, _, err := getCleanupConnectorFromStaging(staging, false)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, status.Errorf(codes.Internal, "load iSCSI connector: %v", err)
+		}
+		conn = nil
 	}
-	if err == nil && !notMnt {
+
+	notMnt, mountErr := ns.mounter.IsLikelyNotMountPoint(staging)
+	if mountErr != nil && !os.IsNotExist(mountErr) {
+		return nil, status.Errorf(codes.Internal, "check staging mount: %v", mountErr)
+	}
+	if mountErr == nil && !notMnt {
 		if err := ns.mounter.Unmount(staging); err != nil {
 			return nil, status.Errorf(codes.Internal, "unstage unmount failed: %v", err)
 		}
 	}
 
 	if conn == nil {
-		conn, _, _ = getConnectorFromStaging(staging, true)
+		conn, _, err = getCleanupConnectorFromStaging(staging, true)
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return nil, status.Errorf(codes.Internal, "load iSCSI connector: %v", err)
+			}
+			conn = nil
+		}
 	}
 
 	if conn != nil {
@@ -672,7 +747,10 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 			return &csi.NodePublishVolumeResponse{}, nil
 		}
 
-		device := conn.MountTargetDevice.GetPath()
+		device := ""
+		if conn.MountTargetDevice != nil {
+			device = conn.MountTargetDevice.GetPath()
+		}
 		if err := ensureFile(req.GetTargetPath()); err != nil {
 			return nil, status.Errorf(codes.Internal, "create block target: %v", err)
 		}
@@ -693,18 +771,23 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	// Tolerate reboot recovery: if staging isn't mounted, recover using connector info.
 	notMnt, merr := ns.mounter.IsLikelyNotMountPoint(staging)
 	if merr == nil && notMnt {
-		if conn, _, err := getConnectorFromStaging(staging, true); err == nil && conn != nil {
-			device := conn.MountTargetDevice.GetPath()
-			if device == "" {
-				device = filepath.Join("/dev/disk/by-path",
-					fmt.Sprintf("ip-%s-iscsi-%s-lun-%d", portal, iqn, lun))
-				if err := ns.waitForPath(device, 60*time.Second); err != nil {
-					return nil, status.Errorf(codes.Internal, "recover staging path: %v", err)
-				}
+		conn, _, err := getConnectorFromStaging(staging, true)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "staging recovery failed: %v", err)
+		}
+		if conn == nil {
+			return nil, status.Error(codes.Internal, "staging recovery failed: connector not found")
+		}
+		device := conn.MountTargetDevice.GetPath()
+		if device == "" {
+			device = filepath.Join("/dev/disk/by-path",
+				fmt.Sprintf("ip-%s-iscsi-%s-lun-%d", portal, iqn, lun))
+			if err := ns.waitForPath(device, 60*time.Second); err != nil {
+				return nil, status.Errorf(codes.Internal, "recover staging path: %v", err)
 			}
-			if err := formatAndMount(ns.mounter, device, staging, fsType, mountOpts); err != nil {
-				return nil, status.Errorf(codes.Internal, "format+mount staging fallback failed: %v", err)
-			}
+		}
+		if err := formatAndMount(ns.mounter, device, staging, fsType, mountOpts); err != nil {
+			return nil, status.Errorf(codes.Internal, "format+mount staging fallback failed: %v", err)
 		}
 	}
 	if err := os.MkdirAll(req.GetTargetPath(), 0o755); err != nil {

--- a/pkg/iscsi/nodeserver.go
+++ b/pkg/iscsi/nodeserver.go
@@ -20,6 +20,8 @@ import (
 // Mockable function references for testing
 var (
 	iscsilibConnect      = func(c *iscsilib.Connector) (string, error) { return c.Connect() }
+	iscsilibDisconnect   = func(c *iscsilib.Connector) error { return c.Disconnect() }
+	disconnectVolume     = func(c *iscsilib.Connector) error { return c.DisconnectVolume() }
 	getConnectorFromFile = iscsilib.GetConnectorFromFile
 	formatAndMount       = func(m *mount.SafeFormatAndMount, source, target, fsType string, options []string) error {
 		return m.FormatAndMount(source, target, fsType, options)
@@ -177,7 +179,37 @@ func (ns *nodeServer) waitForPath(path string, timeout time.Duration) error {
 }
 
 func stageConnectorFile(staging string) string {
+	staging = filepath.Clean(staging)
+	return filepath.Join(filepath.Dir(staging), "."+filepath.Base(staging)+".connector.json")
+}
+
+func legacyStageConnectorFile(staging string) string {
 	return filepath.Join(staging, "connector.json")
+}
+
+func getConnectorFromStaging(staging string, includeLegacy bool) (*iscsilib.Connector, string, error) {
+	paths := []string{stageConnectorFile(staging)}
+	if includeLegacy {
+		paths = append(paths, legacyStageConnectorFile(staging))
+	}
+	var lastErr error
+	for _, path := range paths {
+		conn, err := getConnectorFromFile(path)
+		if err == nil {
+			return conn, path, nil
+		}
+		lastErr = err
+	}
+	return nil, "", lastErr
+}
+
+func removeStagingConnectorFiles(staging string) error {
+	for _, path := range []string{stageConnectorFile(staging), legacyStageConnectorFile(staging)} {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 // ---------- CHAP secrets parsing (matches iscsiadm keys) ----------
@@ -493,8 +525,14 @@ func (ns *nodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 		return nil, status.Errorf(codes.Internal, "iSCSI connect failed: %v", err)
 	}
 
-	// Persist the connector (used by publish/unpublish/unstage)
-	_ = conn.Persist(stageConnectorFile(req.GetStagingTargetPath()))
+	// Persist the connector beside the staging mount so filesystem mounts do not hide it.
+	connectorFile := stageConnectorFile(req.GetStagingTargetPath())
+	if err := os.MkdirAll(filepath.Dir(connectorFile), 0o755); err != nil {
+		return nil, status.Errorf(codes.Internal, "mkdir iSCSI connector directory: %v", err)
+	}
+	if err := conn.Persist(connectorFile); err != nil {
+		return nil, status.Errorf(codes.Internal, "persist iSCSI connector: %v", err)
+	}
 
 	// Block: staging path just needs to exist
 	if req.GetVolumeCapability().GetBlock() != nil {
@@ -528,15 +566,41 @@ func (ns *nodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 		return nil, status.Error(codes.InvalidArgument, "stagingTargetPath missing")
 	}
 
-	// Unmount staging if present
-	if err := mount.CleanupMountPoint(req.GetStagingTargetPath(), ns.mounter, false); err != nil && !os.IsNotExist(err) {
-		return nil, status.Errorf(codes.Internal, "unstage cleanup failed: %v", err)
+	if err := ns.init(); err != nil {
+		return nil, status.Errorf(codes.Internal, "node server init failed: %v", err)
 	}
 
-	// Load connector and disconnect volume (multipath-aware)
-	if conn, err := getConnectorFromFile(stageConnectorFile(req.GetStagingTargetPath())); err == nil {
-		_ = conn.DisconnectVolume()
-		_ = os.Remove(stageConnectorFile(req.GetStagingTargetPath()))
+	staging := req.GetStagingTargetPath()
+	conn, _, _ := getConnectorFromStaging(staging, false)
+
+	notMnt, err := ns.mounter.IsLikelyNotMountPoint(staging)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, status.Errorf(codes.Internal, "check staging mount: %v", err)
+	}
+	if err == nil && !notMnt {
+		if err := ns.mounter.Unmount(staging); err != nil {
+			return nil, status.Errorf(codes.Internal, "unstage unmount failed: %v", err)
+		}
+	}
+
+	if conn == nil {
+		conn, _, _ = getConnectorFromStaging(staging, true)
+	}
+
+	if conn != nil {
+		if err := disconnectVolume(conn); err != nil {
+			return nil, status.Errorf(codes.Internal, "iSCSI disconnect volume failed: %v", err)
+		}
+		if err := iscsilibDisconnect(conn); err != nil {
+			return nil, status.Errorf(codes.Internal, "iSCSI logout failed: %v", err)
+		}
+		if err := removeStagingConnectorFiles(staging); err != nil {
+			return nil, status.Errorf(codes.Internal, "remove iSCSI connector file failed: %v", err)
+		}
+	}
+
+	if err := mount.CleanupMountPoint(staging, ns.mounter, false); err != nil && !os.IsNotExist(err) {
+		return nil, status.Errorf(codes.Internal, "unstage cleanup failed: %v", err)
 	}
 
 	return &csi.NodeUnstageVolumeResponse{}, nil
@@ -587,7 +651,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		if staging == "" {
 			return nil, status.Error(codes.InvalidArgument, "stagingTargetPath is required for block to load connector")
 		}
-		conn, err := getConnectorFromFile(stageConnectorFile(staging))
+		conn, _, err := getConnectorFromStaging(staging, true)
 		if err != nil || conn == nil || conn.MountTargetDevice == nil {
 			// Fallback: compute the by-path and bind mount
 			device := filepath.Join("/dev/disk/by-path",
@@ -629,7 +693,7 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	// Tolerate reboot recovery: if staging isn't mounted, recover using connector info.
 	notMnt, merr := ns.mounter.IsLikelyNotMountPoint(staging)
 	if merr == nil && notMnt {
-		if conn, err := getConnectorFromFile(stageConnectorFile(staging)); err == nil && conn != nil {
+		if conn, _, err := getConnectorFromStaging(staging, true); err == nil && conn != nil {
 			device := conn.MountTargetDevice.GetPath()
 			if device == "" {
 				device = filepath.Join("/dev/disk/by-path",

--- a/pkg/iscsi/nodeserver_test.go
+++ b/pkg/iscsi/nodeserver_test.go
@@ -320,6 +320,56 @@ func TestNodeStageVolume_BlockVolume(t *testing.T) {
 	assert.Empty(t, mockMount.formatAndMounts)
 }
 
+func TestNodeStageVolume_RollsBackConnectionWhenConnectorPersistFails(t *testing.T) {
+	ns, _, _ := newTestNodeServer(t)
+	stagingParent := t.TempDir()
+	stagingTargetPath := filepath.Join(stagingParent, "staging")
+	require.NoError(t, os.MkdirAll(stageConnectorFile(stagingTargetPath), 0o755))
+
+	originalConnect := iscsilibConnect
+	originalDisconnectVolume := disconnectVolume
+	originalDisconnect := iscsilibDisconnect
+	calls := []string{}
+	iscsilibConnect = func(c *iscsilib.Connector) (string, error) {
+		c.MountTargetDevice = &iscsilib.Device{Name: "sdb", Type: "disk"}
+		return "/dev/sdb", nil
+	}
+	disconnectVolume = func(got *iscsilib.Connector) error {
+		calls = append(calls, "device")
+		return nil
+	}
+	iscsilibDisconnect = func(got *iscsilib.Connector) error {
+		calls = append(calls, "session")
+		return errors.New("logout failed")
+	}
+	t.Cleanup(func() {
+		iscsilibConnect = originalConnect
+		disconnectVolume = originalDisconnectVolume
+		iscsilibDisconnect = originalDisconnect
+	})
+
+	resp, err := ns.NodeStageVolume(context.Background(), &csi.NodeStageVolumeRequest{
+		VolumeId:          "test-vol",
+		StagingTargetPath: stagingTargetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+		},
+		PublishContext: map[string]string{
+			"targetPortal": "10.0.0.1:3260",
+			"iqn":          "iqn.2024-01.com.example:test-volume",
+			"lun":          "0",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "persist iSCSI connector")
+	assert.Contains(t, err.Error(), "rollback disconnect failed")
+	assert.Contains(t, err.Error(), "logout failed")
+	assert.Equal(t, []string{"device", "session"}, calls)
+}
+
 func TestNodeStageVolume_StaticISCSIUsesVolumeContextWithoutPublishContext(t *testing.T) {
 	ns, _, _ := newTestNodeServer(t)
 	stagingTargetPath := t.TempDir()
@@ -730,6 +780,53 @@ func TestNodeUnstageVolume_ReadsLegacyConnectorAfterUnmount(t *testing.T) {
 	assert.NoFileExists(t, legacyStageConnectorFile(stagingTargetPath))
 }
 
+func TestNodeUnstageVolume_UsesPersistedConnectorWhenDeviceAlreadyRemoved(t *testing.T) {
+	ns, _, _ := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+	require.NoError(t, os.WriteFile(stageConnectorFile(stagingTargetPath), []byte(`{
+  "target_iqn": "iqn.2024-01.com.example:test-volume",
+  "target_portal": ["10.0.0.1:3260"],
+  "mount_target_device": {"name": "sdb", "hctl": "2:0:0:1", "type": "disk"},
+  "devices": [{"name": "sdb", "hctl": "2:0:0:1", "type": "disk"}]
+}`), 0o600))
+
+	originalGetConnector := getConnectorFromFile
+	originalDisconnectVolume := disconnectVolume
+	originalDisconnect := iscsilibDisconnect
+	calls := []string{}
+	getConnectorFromFile = func(filePath string) (*iscsilib.Connector, error) {
+		assert.Equal(t, stageConnectorFile(stagingTargetPath), filePath)
+		return nil, errors.New("mountTargetDevice /dev/sdb not found")
+	}
+	disconnectVolume = func(got *iscsilib.Connector) error {
+		assert.Equal(t, "iqn.2024-01.com.example:test-volume", got.TargetIqn)
+		require.NotNil(t, got.MountTargetDevice)
+		assert.Equal(t, filepath.Join("/dev", "sdb"), got.MountTargetDevice.GetPath())
+		calls = append(calls, "device")
+		return nil
+	}
+	iscsilibDisconnect = func(got *iscsilib.Connector) error {
+		assert.Equal(t, "iqn.2024-01.com.example:test-volume", got.TargetIqn)
+		calls = append(calls, "session")
+		return nil
+	}
+	t.Cleanup(func() {
+		getConnectorFromFile = originalGetConnector
+		disconnectVolume = originalDisconnectVolume
+		iscsilibDisconnect = originalDisconnect
+	})
+
+	resp, err := ns.NodeUnstageVolume(context.Background(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          "test-vol",
+		StagingTargetPath: stagingTargetPath,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, []string{"device", "session"}, calls)
+	assert.NoFileExists(t, stageConnectorFile(stagingTargetPath))
+}
+
 func TestNodeUnstageVolume_ReturnsErrorWhenSessionDisconnectFails(t *testing.T) {
 	ns, _, _ := newTestNodeServer(t)
 	stagingTargetPath := t.TempDir()
@@ -759,6 +856,38 @@ func TestNodeUnstageVolume_ReturnsErrorWhenSessionDisconnectFails(t *testing.T) 
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "iSCSI logout failed")
+}
+
+func TestNodeUnstageVolume_ReturnsErrorForMalformedConnector(t *testing.T) {
+	ns, _, _ := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+	require.NoError(t, os.WriteFile(stageConnectorFile(stagingTargetPath), []byte(`not-json`), 0o600))
+
+	resp, err := ns.NodeUnstageVolume(context.Background(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          "test-vol",
+		StagingTargetPath: stagingTargetPath,
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "load iSCSI connector")
+}
+
+func TestNodeUnstageVolume_ReturnsErrorForMalformedLegacyConnectorAfterUnmount(t *testing.T) {
+	ns, _, mockMount := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+	mockMount.mountPaths = []string{stagingTargetPath}
+	require.NoError(t, os.WriteFile(legacyStageConnectorFile(stagingTargetPath), []byte(`not-json`), 0o600))
+
+	resp, err := ns.NodeUnstageVolume(context.Background(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          "test-vol",
+		StagingTargetPath: stagingTargetPath,
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, []string{stagingTargetPath}, mockMount.unmountPaths)
+	assert.Contains(t, err.Error(), "load iSCSI connector")
 }
 
 // ---------------------------------------------------------------------------
@@ -893,6 +1022,7 @@ func TestNodePublishVolume_StaticISCSIUsesVolumeContextWithoutPublishContext(t *
 	ns, _, mockMount := newTestNodeServer(t)
 	stagingTargetPath := t.TempDir()
 	targetPath := t.TempDir()
+	mockMount.mountPaths = []string{stagingTargetPath}
 
 	resp, err := ns.NodePublishVolume(context.Background(), &csi.NodePublishVolumeRequest{
 		VolumeId:          "static-iscsi-volume",
@@ -974,6 +1104,7 @@ func TestNodePublishVolume_FilesystemVolume(t *testing.T) {
 	ns, _, mockMount := newTestNodeServer(t)
 	stagingTargetPath := t.TempDir()
 	targetPath := t.TempDir()
+	mockMount.mountPaths = []string{stagingTargetPath}
 
 	_, err := ns.NodePublishVolume(context.Background(), &csi.NodePublishVolumeRequest{
 		VolumeId:          "test-vol",
@@ -1003,6 +1134,7 @@ func TestNodePublishVolume_ReadOnly(t *testing.T) {
 	ns, _, mockMount := newTestNodeServer(t)
 	stagingTargetPath := t.TempDir()
 	targetPath := t.TempDir()
+	mockMount.mountPaths = []string{stagingTargetPath}
 
 	_, err := ns.NodePublishVolume(context.Background(), &csi.NodePublishVolumeRequest{
 		VolumeId:          "test-vol",
@@ -1077,6 +1209,104 @@ func TestNodePublishVolume_RecoverStagingUsesVolumeCapabilityFsType(t *testing.T
 	assert.Equal(t, stagingTargetPath, mockMount.formatAndMounts[0].source)
 	assert.Equal(t, targetPath, mockMount.formatAndMounts[0].target)
 	assert.Contains(t, mockMount.formatAndMounts[0].options, "bind")
+}
+
+func TestNodePublishVolume_RecoverStagingReturnsErrorWhenConnectorMissing(t *testing.T) {
+	ns, _, mockMount := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+	targetPath := t.TempDir()
+
+	resp, err := ns.NodePublishVolume(context.Background(), &csi.NodePublishVolumeRequest{
+		VolumeId:          "test-vol",
+		TargetPath:        targetPath,
+		StagingTargetPath: stagingTargetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{FsType: "xfs"}},
+		},
+		PublishContext: map[string]string{
+			"targetPortal": "10.0.0.1:3260",
+			"iqn":          "iqn.2024-01.com.example:test-volume",
+			"lun":          "0",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "staging recovery failed")
+	assert.Empty(t, mockMount.formatAndMounts)
+}
+
+func TestNodePublishVolume_RecoverStagingReturnsErrorWhenConnectorNil(t *testing.T) {
+	ns, _, _ := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+	targetPath := t.TempDir()
+
+	originalGetConnector := getConnectorFromFile
+	getConnectorFromFile = func(filePath string) (*iscsilib.Connector, error) {
+		return nil, nil
+	}
+	t.Cleanup(func() { getConnectorFromFile = originalGetConnector })
+
+	resp, err := ns.NodePublishVolume(context.Background(), &csi.NodePublishVolumeRequest{
+		VolumeId:          "test-vol",
+		TargetPath:        targetPath,
+		StagingTargetPath: stagingTargetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{FsType: "xfs"}},
+		},
+		PublishContext: map[string]string{
+			"targetPortal": "10.0.0.1:3260",
+			"iqn":          "iqn.2024-01.com.example:test-volume",
+			"lun":          "0",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "connector not found")
+}
+
+func TestNodePublishVolume_RecoverStagingReturnsErrorWhenFormatMountFails(t *testing.T) {
+	ns, _, _ := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+	targetPath := t.TempDir()
+	conn := &iscsilib.Connector{
+		MountTargetDevice: &iscsilib.Device{Name: "sdb", Type: "disk"},
+	}
+
+	originalGetConnector := getConnectorFromFile
+	originalFormatAndMount := formatAndMount
+	getConnectorFromFile = func(filePath string) (*iscsilib.Connector, error) {
+		return conn, nil
+	}
+	formatAndMount = func(m *mount.SafeFormatAndMount, source, target, fsType string, options []string) error {
+		return errors.New("format failed")
+	}
+	t.Cleanup(func() {
+		getConnectorFromFile = originalGetConnector
+		formatAndMount = originalFormatAndMount
+	})
+
+	resp, err := ns.NodePublishVolume(context.Background(), &csi.NodePublishVolumeRequest{
+		VolumeId:          "test-vol",
+		TargetPath:        targetPath,
+		StagingTargetPath: stagingTargetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+			AccessType: &csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{FsType: "xfs"}},
+		},
+		PublishContext: map[string]string{
+			"targetPortal": "10.0.0.1:3260",
+			"iqn":          "iqn.2024-01.com.example:test-volume",
+			"lun":          "0",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "format+mount staging fallback failed")
 }
 
 func TestNodePublishVolume_FileShareBind(t *testing.T) {

--- a/pkg/iscsi/nodeserver_test.go
+++ b/pkg/iscsi/nodeserver_test.go
@@ -48,7 +48,7 @@ func (m *mockMount) IsMountPoint(file string) (bool, error) {
 			return false, err
 		}
 	}
-	return true, nil
+	return containsString(m.mountPaths, file), nil
 }
 
 func (m *mockMount) IsLikelyNotMountPoint(file string) (bool, error) {
@@ -57,7 +57,7 @@ func (m *mockMount) IsLikelyNotMountPoint(file string) (bool, error) {
 			return false, err
 		}
 	}
-	return true, nil
+	return !containsString(m.mountPaths, file), nil
 }
 
 func (m *mockMount) CanSafelySkipMountPointCheck() bool {
@@ -88,7 +88,22 @@ func (m *mockMount) MountSensitiveWithoutSystemdWithMountFlags(source, target, f
 
 func (m *mockMount) Unmount(target string) error {
 	m.unmountPaths = append(m.unmountPaths, target)
+	for i, path := range m.mountPaths {
+		if path == target {
+			m.mountPaths = append(m.mountPaths[:i], m.mountPaths[i+1:]...)
+			break
+		}
+	}
 	return nil
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +154,13 @@ func TestNodeStageVolume_VolumeCapabilityRequired(t *testing.T) {
 	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "volumeCapability missing")
+}
+
+func TestStageConnectorFileIsOutsideStagingMount(t *testing.T) {
+	stagingTargetPath := filepath.Join(t.TempDir(), "globalmount")
+
+	assert.Equal(t, filepath.Dir(stagingTargetPath), filepath.Dir(stageConnectorFile(stagingTargetPath)))
+	assert.NotEqual(t, legacyStageConnectorFile(stagingTargetPath), stageConnectorFile(stagingTargetPath))
 }
 
 func TestNodeStageVolume_IscsiConnectionRequired(t *testing.T) {
@@ -612,6 +634,131 @@ func TestNodeUnstageVolume_Success(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
+}
+
+func TestNodeUnstageVolume_DisconnectsISCSISession(t *testing.T) {
+	ns, _, mockMount := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+	mockMount.mountPaths = []string{stagingTargetPath}
+	conn := &iscsilib.Connector{
+		TargetIqn:     "iqn.2024-01.com.example:test-volume",
+		TargetPortals: []string{"10.0.0.1:3260"},
+	}
+
+	originalGetConnector := getConnectorFromFile
+	originalDisconnectVolume := disconnectVolume
+	originalDisconnect := iscsilibDisconnect
+	calls := []string{}
+	getConnectorFromFile = func(filePath string) (*iscsilib.Connector, error) {
+		assert.Equal(t, stageConnectorFile(stagingTargetPath), filePath)
+		return conn, nil
+	}
+	disconnectVolume = func(got *iscsilib.Connector) error {
+		assert.Same(t, conn, got)
+		assert.Equal(t, []string{stagingTargetPath}, mockMount.unmountPaths)
+		calls = append(calls, "device")
+		return nil
+	}
+	iscsilibDisconnect = func(got *iscsilib.Connector) error {
+		assert.Same(t, conn, got)
+		calls = append(calls, "session")
+		return nil
+	}
+	t.Cleanup(func() {
+		getConnectorFromFile = originalGetConnector
+		disconnectVolume = originalDisconnectVolume
+		iscsilibDisconnect = originalDisconnect
+	})
+
+	resp, err := ns.NodeUnstageVolume(context.Background(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          "test-vol",
+		StagingTargetPath: stagingTargetPath,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, []string{"device", "session"}, calls)
+}
+
+func TestNodeUnstageVolume_ReadsLegacyConnectorAfterUnmount(t *testing.T) {
+	ns, _, mockMount := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+	mockMount.mountPaths = []string{stagingTargetPath}
+	require.NoError(t, os.WriteFile(legacyStageConnectorFile(stagingTargetPath), []byte(`{
+  "target_iqn": "iqn.2024-01.com.example:test-volume",
+  "target_portal": ["10.0.0.1:3260"],
+  "mount_target_device": {"name": "sdb", "type": "disk"},
+  "devices": [{"name": "sdb", "type": "disk"}]
+}`), 0o600))
+
+	originalGetConnector := getConnectorFromFile
+	originalDisconnectVolume := disconnectVolume
+	originalDisconnect := iscsilibDisconnect
+	var disconnected bool
+	getConnectorFromFile = func(filePath string) (*iscsilib.Connector, error) {
+		if filePath == legacyStageConnectorFile(stagingTargetPath) && len(mockMount.unmountPaths) > 0 {
+			return &iscsilib.Connector{
+				TargetIqn:     "iqn.2024-01.com.example:test-volume",
+				TargetPortals: []string{"10.0.0.1:3260"},
+			}, nil
+		}
+		return nil, os.ErrNotExist
+	}
+	disconnectVolume = func(got *iscsilib.Connector) error {
+		assert.Equal(t, "iqn.2024-01.com.example:test-volume", got.TargetIqn)
+		disconnected = true
+		return nil
+	}
+	iscsilibDisconnect = func(got *iscsilib.Connector) error {
+		assert.True(t, disconnected)
+		return nil
+	}
+	t.Cleanup(func() {
+		getConnectorFromFile = originalGetConnector
+		disconnectVolume = originalDisconnectVolume
+		iscsilibDisconnect = originalDisconnect
+	})
+
+	resp, err := ns.NodeUnstageVolume(context.Background(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          "test-vol",
+		StagingTargetPath: stagingTargetPath,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.True(t, disconnected)
+	assert.NoFileExists(t, legacyStageConnectorFile(stagingTargetPath))
+}
+
+func TestNodeUnstageVolume_ReturnsErrorWhenSessionDisconnectFails(t *testing.T) {
+	ns, _, _ := newTestNodeServer(t)
+	stagingTargetPath := t.TempDir()
+
+	originalGetConnector := getConnectorFromFile
+	originalDisconnectVolume := disconnectVolume
+	originalDisconnect := iscsilibDisconnect
+	getConnectorFromFile = func(filePath string) (*iscsilib.Connector, error) {
+		return &iscsilib.Connector{}, nil
+	}
+	disconnectVolume = func(got *iscsilib.Connector) error {
+		return nil
+	}
+	iscsilibDisconnect = func(got *iscsilib.Connector) error {
+		return errors.New("logout failed")
+	}
+	t.Cleanup(func() {
+		getConnectorFromFile = originalGetConnector
+		disconnectVolume = originalDisconnectVolume
+		iscsilibDisconnect = originalDisconnect
+	})
+
+	_, err := ns.NodeUnstageVolume(context.Background(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          "test-vol",
+		StagingTargetPath: stagingTargetPath,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "iSCSI logout failed")
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/iscsilib/iscsi.go
+++ b/pkg/iscsilib/iscsi.go
@@ -393,30 +393,28 @@ func (c *Connector) discoverTarget(targetIqn string, iFace string, portal string
 }
 
 // Disconnect is for backward-compatibility with c.Disconnect()
-func Disconnect(targetIqn string, targets []string) {
+func Disconnect(targetIqn string, targets []string) error {
+	var errs []error
 	for _, target := range targets {
-		targetPortal := strings.Split(target, ":")[0]
-		err := Logout(targetIqn, targetPortal)
-		if err != nil {
-			return
+		targetPortal := strings.TrimSpace(target)
+		if targetPortal == "" {
+			continue
+		}
+		if err := Logout(targetIqn, targetPortal); err != nil {
+			errs = append(errs, fmt.Errorf("logout from portal %s: %w", targetPortal, err))
 		}
 	}
 
-	deleted := map[string]bool{}
-	if _, ok := deleted[targetIqn]; ok {
-		return
+	if err := DeleteDBEntry(targetIqn); err != nil {
+		errs = append(errs, fmt.Errorf("delete iSCSI node db entry: %w", err))
 	}
-	deleted[targetIqn] = true
-	err := DeleteDBEntry(targetIqn)
-	if err != nil {
-		return
-	}
+	return errors.Join(errs...)
 }
 
 // Disconnect performs a disconnect operation from an appliance.
 // Be sure to disconnect all devices properly before doing this as it can result in data loss.
-func (c *Connector) Disconnect() {
-	Disconnect(c.TargetIqn, c.TargetPortals)
+func (c *Connector) Disconnect() error {
+	return Disconnect(c.TargetIqn, c.TargetPortals)
 }
 
 // DisconnectVolume removes a volume from a Linux host.

--- a/pkg/iscsilib/iscsi_test.go
+++ b/pkg/iscsilib/iscsi_test.go
@@ -305,6 +305,17 @@ func TestConnectorPersistAndGetConnectorFromFile(t *testing.T) {
 	assert.Equal(t, "sdb", got.Devices[0].Name)
 }
 
+func TestDisconnectLogsOutFullPortalAndDeletesDBEntry(t *testing.T) {
+	calls := captureExecWithTimeout(t, nil, nil)
+
+	err := Disconnect("iqn.2024-01.com.example:vol-001", []string{"10.0.0.1:3260"})
+
+	require.NoError(t, err)
+	require.Len(t, *calls, 2)
+	assert.Equal(t, []string{"-m", "node", "-T", "iqn.2024-01.com.example:vol-001", "-p", "10.0.0.1:3260", "-u"}, (*calls)[0].args)
+	assert.Equal(t, []string{"-m", "node", "-T", "iqn.2024-01.com.example:vol-001", "-o", "delete"}, (*calls)[1].args)
+}
+
 func TestGetConnectorFromFileRequiresMountTargetDevice(t *testing.T) {
 	filePath := filepath.Join(t.TempDir(), "connector.json")
 	require.NoError(t, os.WriteFile(filePath, []byte(`{"volume_name":"vol-001"}`), 0o600))

--- a/pkg/iscsilib/iscsiadm.go
+++ b/pkg/iscsilib/iscsiadm.go
@@ -186,7 +186,11 @@ func Login(tgtIQN, portal string) error {
 func Logout(tgtIQN, portal string) error {
 	klog.V(2).Infof("Begin Logout...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-p", portal, "-u"}
-	_, err := iscsiCmd(args...)
+	out, err := iscsiCmd(args...)
+	if err != nil && isISCSIAlreadyAbsent(out, err) {
+		klog.V(2).Infof("iSCSI session for target %s at portal %s is already absent: %v", tgtIQN, portal, err)
+		return nil
+	}
 	return err
 }
 
@@ -194,8 +198,57 @@ func Logout(tgtIQN, portal string) error {
 func DeleteDBEntry(tgtIQN string) error {
 	klog.V(2).Infof("Begin DeleteDBEntry...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-o", "delete"}
-	_, err := iscsiCmd(args...)
+	out, err := iscsiCmd(args...)
+	if err != nil && isISCSINodeDBEntryAlreadyAbsent(out, err) {
+		klog.V(2).Infof("iSCSI node DB entry for target %s is already absent: %v", tgtIQN, err)
+		return nil
+	}
 	return err
+}
+
+func isISCSIAlreadyAbsent(output string, err error) bool {
+	if err == nil {
+		return false
+	}
+	outputMsg := strings.ToLower(output)
+	errMsg := strings.ToLower(err.Error())
+	msg := outputMsg + " " + errMsg
+	for _, marker := range []string{
+		"no matching sessions",
+		"no records found",
+		"no record found",
+		"not currently logged in",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	if strings.TrimSpace(outputMsg) == "" {
+		return false
+	}
+	for _, marker := range []string{
+		"not found",
+		"does not exist",
+		"not exist",
+		"could not find",
+	} {
+		if strings.Contains(outputMsg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func isISCSINodeDBEntryAlreadyAbsent(output string, err error) bool {
+	if isISCSIAlreadyAbsent(output, err) {
+		return true
+	}
+	if strings.TrimSpace(output) == "" {
+		return false
+	}
+	msg := strings.ToLower(output + " " + err.Error())
+	return strings.Contains(msg, "could not execute operation on all records") &&
+		strings.Contains(msg, "database failure")
 }
 
 // DeleteIFace delete the iface

--- a/pkg/iscsilib/iscsiadm_test.go
+++ b/pkg/iscsilib/iscsiadm_test.go
@@ -79,8 +79,32 @@ func TestIscsiAdmWrappers(t *testing.T) {
 		assert.Equal(t, []string{"-m", "node", "-T", "iqn.2024-01.com.example:vol", "-p", "10.0.0.1:3260", "-u"}, (*calls)[0].args)
 	})
 
+	t.Run("logout ignores already absent session", func(t *testing.T) {
+		calls := captureExecWithTimeout(t, []string{"iscsiadm: No matching sessions found\n"}, []error{errors.New("exit status 21")})
+
+		require.NoError(t, Logout("iqn.2024-01.com.example:vol", "10.0.0.1:3260"))
+		require.Len(t, *calls, 1)
+		assert.Equal(t, []string{"-m", "node", "-T", "iqn.2024-01.com.example:vol", "-p", "10.0.0.1:3260", "-u"}, (*calls)[0].args)
+	})
+
+	t.Run("logout returns command errors", func(t *testing.T) {
+		captureExecWithTimeout(t, nil, []error{errors.New(`exec: "iscsiadm": executable file not found`)})
+
+		err := Logout("iqn.2024-01.com.example:vol", "10.0.0.1:3260")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "executable file not found")
+	})
+
 	t.Run("delete db entry", func(t *testing.T) {
 		calls := captureExecWithTimeout(t, nil, nil)
+
+		require.NoError(t, DeleteDBEntry("iqn.2024-01.com.example:vol"))
+		require.Len(t, *calls, 1)
+		assert.Equal(t, []string{"-m", "node", "-T", "iqn.2024-01.com.example:vol", "-o", "delete"}, (*calls)[0].args)
+	})
+
+	t.Run("delete db entry ignores already absent record", func(t *testing.T) {
+		calls := captureExecWithTimeout(t, []string{"iscsiadm: Could not execute operation on all records: encountered iSCSI database failure\n"}, []error{errors.New("exit status 21")})
 
 		require.NoError(t, DeleteDBEntry("iqn.2024-01.com.example:vol"))
 		require.Len(t, *calls, 1)


### PR DESCRIPTION
Ensure that deletion of PV happens for each storage type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on volume deletion behavior, Windows cleanup semantics, and a mode-by-mode cleanup table; clarified PostgreSQL example configuration.

* **Bug Fixes**
  * Strengthened cleanup and error handling for file-share, virtual-disk, and iSCSI operations so failures are surfaced rather than silently ignored.
  * Improved connector persistence and recovery behavior during node stage/unstage and publish/unpublish operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->